### PR TITLE
Refactor logging system to use lazy callback pattern

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
@@ -1,13 +1,50 @@
 package org.komapper.extension.validator
 
+/**
+ * Type alias for validators that validate constraints without transforming the type.
+ *
+ * A ConstraintValidator is an [IdentityValidator] that checks constraints on input values,
+ * returning the same value if constraints are satisfied, or validation failures if violated.
+ */
 typealias ConstraintValidator<T> = IdentityValidator<T>
 
+/**
+ * Creates a ConstraintValidator from a [Constraint].
+ *
+ * This factory function converts a constraint into a validator that executes the constraint
+ * and converts the [ConstraintResult] into a [ValidationResult]. It also logs the validation
+ * result if logging is enabled in the [ValidationConfig].
+ *
+ * When a constraint is satisfied, the input value is returned unchanged wrapped in a Success.
+ * When violated, the constraint's error message is returned in a Failure.
+ *
+ * Example:
+ * ```kotlin
+ * val constraint = Constraint("kova.string.min") { ctx ->
+ *     satisfies(ctx.input.length >= 3, "Must be at least 3 characters")
+ * }
+ * val validator = ConstraintValidator(constraint)
+ * ```
+ *
+ * @param constraint The constraint to apply
+ * @return A validator that checks the constraint and returns the input unchanged if satisfied
+ */
 fun <T> ConstraintValidator(constraint: Constraint<T>): ConstraintValidator<T> =
     Validator { input, context ->
-        val context = context.addLog(constraint.id)
         val constraintContext = context.createConstraintContext(input, constraint.id)
         when (val result = constraint.apply(constraintContext)) {
-            is ConstraintResult.Satisfied -> ValidationResult.Success(input, context)
-            is ConstraintResult.Violated -> ValidationResult.Failure(listOf(result.message))
+            is ConstraintResult.Satisfied -> {
+                context.log {
+                    "Satisfied(constraintId=${constraint.id}, root=${context.root}, path=${context.path.fullName}, input=$input)"
+                }
+                ValidationResult.Success(input, context)
+            }
+
+            is ConstraintResult.Violated -> {
+                context.log {
+                    "Violated(constraintId=${constraint.id}, root=${context.root}, path=${context.path.fullName}, input=$input)"
+                }
+                ValidationResult.Failure(listOf(result.message))
+            }
         }
     }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/IdentityValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/IdentityValidator.kt
@@ -136,7 +136,6 @@ fun <T> IdentityValidator<T>.onlyIf(condition: (T) -> Boolean) =
  */
 fun <T> IdentityValidator<T>.chain(next: IdentityValidator<T>): IdentityValidator<T> =
     IdentityValidator { input, context ->
-        val context = context.addLog("Validator.chain")
         when (val result = this.execute(input, context)) {
             is Success -> {
                 next.execute(result.value, result.context)

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
@@ -40,7 +40,6 @@ typealias NullableValidator<T, S> = Validator<T?, S?>
  */
 fun <T : Any, S : Any> Validator<T, S>.asNullable(): NullableValidator<T, S> =
     Validator { input, context ->
-        val context = context.addLog("Validator.asNullable")
         if (input == null) Success(null, context) else this.execute(input, context)
     }
 

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/Validator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/Validator.kt
@@ -117,7 +117,6 @@ operator fun <IN, OUT> Validator<IN, OUT>.plus(other: Validator<IN, OUT>): Valid
 infix fun <IN, OUT> Validator<IN, OUT>.and(other: Validator<IN, OUT>): Validator<IN, OUT> {
     val self = this
     return Validator { input, context ->
-        val context = context.addLog("Validator.and")
         when (val selfResult = self.execute(input, context)) {
             is Success -> {
                 val otherResult = other.execute(input, context)
@@ -155,7 +154,6 @@ infix fun <IN, OUT> Validator<IN, OUT>.and(other: Validator<IN, OUT>): Validator
 infix fun <IN, OUT> Validator<IN, OUT>.or(other: Validator<IN, OUT>): Validator<IN, OUT> {
     val self = this
     return Validator { input, context ->
-        val context = context.addLog("Validator.or")
         when (val selfResult = self.execute(input, context)) {
             is Success -> selfResult
             is Failure -> {
@@ -190,7 +188,6 @@ infix fun <IN, OUT> Validator<IN, OUT>.or(other: Validator<IN, OUT>): Validator<
 fun <IN, OUT, NEW> Validator<IN, OUT>.map(transform: (OUT) -> NEW): Validator<IN, NEW> {
     val self = this
     return Validator { input, context ->
-        val context = context.addLog("Validator.map")
         when (val result = self.execute(input, context)) {
             is Success -> tryTransform(result.value, result.context, transform)
             is Failure -> result
@@ -215,7 +212,7 @@ fun <IN, OUT, NEW> Validator<IN, OUT>.map(transform: (OUT) -> NEW): Validator<IN
 fun <IN, OUT> Validator<IN, OUT>.name(name: String): Validator<IN, OUT> {
     val self = this
     return Validator { input, context ->
-        val context = context.addPath(name, input).addLog("Validator.name(name=$name)")
+        val context = context.addPath(name, input)
         when (val result = self.execute(input, context)) {
             is Success -> Success(result.value, result.context)
             is Failure -> result
@@ -257,7 +254,6 @@ fun <IN, OUT, NEW> Validator<OUT, NEW>.compose(before: Validator<IN, OUT>): Vali
 fun <IN, OUT, NEW> Validator<IN, OUT>.then(after: Validator<OUT, NEW>): Validator<IN, NEW> {
     val before = this
     return Validator { input, context ->
-        val context = context.addLog("Validator.then")
         when (val result = before.execute(input, context)) {
             is Success -> after.execute(result.value, result.context)
             is Failure -> result

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/WithDefaultNullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/WithDefaultNullableValidator.kt
@@ -61,7 +61,6 @@ fun <T : Any, S : Any> Validator<T, S>.asNullable(defaultValue: S): WithDefaultN
 fun <T : Any, S : Any> Validator<T, S>.asNullable(withDefault: () -> S): WithDefaultNullableValidator<T, S> =
     Validator { input, context ->
         val defaultValue = withDefault()
-        val context = context.addLog("Validator.asNullable(defaultValue=$defaultValue)")
         if (input == null) Success(defaultValue, context) else execute(input, context)
     }
 

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
@@ -279,15 +279,23 @@ class NullableValidatorTest :
             val isNullOrMin3Max3 = Kova.nullable<Int>().isNull().or(min3)
 
             test("success: 3") {
-                val result = isNullOrMin3Max3.tryValidate(3)
+                val logs = mutableListOf<String>()
+                val config = ValidationConfig(logger = { logs.add(it) })
+                val result = isNullOrMin3Max3.tryValidate(3, config = config)
                 result.isSuccess().mustBeTrue()
-                println(result.context.logs.joinToString("\n"))
+                logs shouldBe
+                    listOf(
+                        "Violated(constraintId=kova.nullable.isNull, root=, path=, input=3)",
+                        "Satisfied(constraintId=kova.comparable.min, root=, path=, input=3)",
+                    )
             }
 
             test("success: null") {
-                val result = isNullOrMin3Max3.tryValidate(null)
+                val logs = mutableListOf<String>()
+                val config = ValidationConfig(logger = { logs.add(it) })
+                val result = isNullOrMin3Max3.tryValidate(null, config = config)
                 result.isSuccess().mustBeTrue()
-                println(result.context.logs.joinToString("\n"))
+                logs shouldBe listOf("Satisfied(constraintId=kova.nullable.isNull, root=, path=, input=null)")
             }
         }
     })

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
@@ -155,38 +155,32 @@ class ValidatorTest :
             }
         }
 
-        // TODO
-        xcontext("logs") {
+        context("logs") {
             val validator =
-                Kova
-                    .string()
-                    .trim()
-                    .min(3)
-                    .max(5)
+                Kova.string().trim().then(Kova.string().min(3).max(5))
 
             test("success") {
-                val result = validator.tryValidate(" abcde ", ValidationConfig(logging = true))
+                val logs = mutableListOf<String>()
+                val result = validator.tryValidate(" abcde ", ValidationConfig(logger = { logs.add(it) }))
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "abcde"
-                result.context.logs shouldBe
+
+                logs shouldBe
                     listOf(
-                        "StringValidator(name=kova.string.max)",
-                        "Validator.chain",
-                        "Validator.map",
-                        "StringValidator(name=kova.string.min)",
-                        "Validator.chain",
-                        "Validator.map",
-                        "StringValidator(name=trim)",
-                        "Validator.chain",
-                        "Validator.map",
-                        "StringValidator(name=empty)",
-                        "Validator.chain",
-                        "Validator.map",
-                        "EmptyValidator",
-                        "ConstraintValidator(name=kova.satisfied)",
-                        "ConstraintValidator(name=kova.satisfied)",
-                        "ConstraintValidator(name=kova.string.min)",
-                        "ConstraintValidator(name=kova.string.max)",
+                        "Satisfied(constraintId=kova.string.min, root=, path=, input=abcde)",
+                        "Satisfied(constraintId=kova.string.max, root=, path=, input=abcde)",
+                    )
+            }
+
+            test("failure") {
+                val logs = mutableListOf<String>()
+                val result = validator.tryValidate(" ab ", ValidationConfig(logger = { logs.add(it) }))
+                result.isFailure().mustBeTrue()
+
+                logs shouldBe
+                    listOf(
+                        "Violated(constraintId=kova.string.min, root=, path=, input=ab)",
+                        "Satisfied(constraintId=kova.string.max, root=, path=, input=ab)",
                     )
             }
         }

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
@@ -172,9 +172,11 @@ class WithDefaultNullableValidatorTest :
             }
 
             test("success - null") {
-                val result = whenNotNullMin3.tryValidate(null)
+                val logs = mutableListOf<String>()
+                val result = whenNotNullMin3.tryValidate(null, config = ValidationConfig(logger = { logs.add(it) }))
                 result.isSuccess().mustBeTrue(result)
-                println(result.context.logs.joinToString("\n"))
+                result.value shouldBe 0
+                logs shouldBe listOf()
             }
 
             test("failure - min 3constraint violated") {
@@ -270,17 +272,28 @@ class WithDefaultNullableValidatorTest :
             val isNullOrMin3Max3 = Kova.nullable(0).isNull().or(min3.asNullable(0))
 
             test("success: 3") {
-                val result = isNullOrMin3Max3.tryValidate(3)
+                val logs = mutableListOf<String>()
+                val config = ValidationConfig(logger = { logs.add(it) })
+                val result = isNullOrMin3Max3.tryValidate(3, config = config)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 3
-                println(result.context.logs.joinToString("\n"))
+                logs shouldBe
+                    listOf(
+                        "Violated(constraintId=kova.nullable.isNull, root=, path=, input=3)",
+                        "Satisfied(constraintId=kova.comparable.min, root=, path=, input=3)",
+                    )
             }
 
             test("success: null") {
-                val result = isNullOrMin3Max3.tryValidate(null)
+                val logs = mutableListOf<String>()
+                val config = ValidationConfig(logger = { logs.add(it) })
+                val result = isNullOrMin3Max3.tryValidate(null, config = config)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0
-                println(result.context.logs.joinToString("\n"))
+                logs shouldBe
+                    listOf(
+                        "Satisfied(constraintId=kova.nullable.isNull, root=, path=, input=null)",
+                    )
             }
         }
     })


### PR DESCRIPTION
## Summary
Refactored the validation logging system from eager accumulation to lazy callback pattern for better performance and flexibility.

### Changes
- **ValidationConfig**: Changed from `logging: Boolean` + `logs: List<String>` to `logger: ((String) -> Unit)?`
- **ValidationContext**: Removed `logs` property and `addLog()` method
- **New logging API**: Added `ValidationContext.log(block: () -> String)` with lazy evaluation
- **ConstraintValidator**: Now logs constraint satisfaction/violation results
- **Validator composition**: Removed all intermediate `addLog()` calls from operators (`and`, `or`, `map`, `then`, `chain`)
- **Documentation**: Added comprehensive KDoc for all logging-related APIs
- **Tests**: Updated to use new logging callback pattern

### Benefits
1. **Zero overhead**: Log messages are only built when logging is enabled (lazy evaluation)
2. **Flexible output**: Logger callback can send logs anywhere (console, file, monitoring systems)
3. **No memory accumulation**: Logs are streamed rather than stored in ValidationContext
4. **Cleaner API**: Simplified logging configuration and usage

### Example Usage
```kotlin
val config = ValidationConfig(
    logger = { message -> println(message) }
)
val result = Kova.string().min(3).tryValidate("hello", config)
// Logs: "Satisfied(constraintId=kova.string.min, root=, path=, input=hello)"
```

### Breaking Changes
- `ValidationConfig.logging: Boolean` → `ValidationConfig.logger: ((String) -> Unit)?`
- `ValidationContext.logs: List<String>` removed
- `ValidationContext.addLog(String)` removed

## Test Plan
- [x] All existing tests pass
- [x] Updated logging tests to verify new callback behavior
- [x] Verified lazy evaluation (callback only invoked when logger is configured)
- [x] Verified log message format includes constraint ID, root, path, and input

🤖 Generated with [Claude Code](https://claude.com/claude-code)