### PR TITLE
Refactor WithDefaultNullableValidator from type alias to interface

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
@@ -157,7 +157,8 @@ fun <T : Any, S : Any> NullableValidator<T, S>.withDefault(defaultValue: S): Wit
  * @param provide Function that generates the default value
  * @return A new validator with non-nullable output that uses the provided default for null inputs
  */
-fun <T : Any, S : Any> NullableValidator<T, S>.withDefault(provide: () -> S): WithDefaultNullableValidator<T, S> = map { it ?: provide() }
+fun <T : Any, S : Any> NullableValidator<T, S>.withDefault(provide: () -> S): WithDefaultNullableValidator<T, S> =
+    WithDefaultNullableValidator(map { it ?: provide() }, provide)
 
 /**
  * Operator overload for [and]. Combines this nullable validator with a non-nullable validator.

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/WithDefaultNullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/WithDefaultNullableValidator.kt
@@ -3,7 +3,7 @@ package org.komapper.extension.validator
 import org.komapper.extension.validator.ValidationResult.Success
 
 /**
- * Type alias for validators that accept nullable input but produce non-nullable output.
+ * Type interface for validators that accept nullable input but produce non-nullable output.
  *
  * This validator has a default value that is used when the input is null,
  * ensuring the output is always non-null.
@@ -21,7 +21,34 @@ import org.komapper.extension.validator.ValidationResult.Success
  * @param T The non-null input type
  * @param S The non-null output type (always non-null due to default)
  */
-typealias WithDefaultNullableValidator<T, S> = Validator<T?, S>
+interface WithDefaultNullableValidator<T : Any, S : Any> : Validator<T?, S> {
+    operator fun plus(other: Validator<T, S>): WithDefaultNullableValidator<T, S> = and(other)
+
+    infix fun and(other: Validator<T, S>): WithDefaultNullableValidator<T, S>
+
+    infix fun or(other: Validator<T, S>): WithDefaultNullableValidator<T, S>
+}
+
+internal fun <T : Any, S : Any> WithDefaultNullableValidator(
+    validator: Validator<T?, S>,
+    provide: () -> S,
+): WithDefaultNullableValidator<T, S> =
+    object : WithDefaultNullableValidator<T, S> {
+        override fun execute(
+            input: T?,
+            context: ValidationContext,
+        ): ValidationResult<S> = validator.execute(input, context)
+
+        override fun and(other: Validator<T, S>): WithDefaultNullableValidator<T, S> {
+            val and = validator and other.asNullable(provide)
+            return WithDefaultNullableValidator(and, provide)
+        }
+
+        override fun or(other: Validator<T, S>): WithDefaultNullableValidator<T, S> {
+            val or = validator or other.asNullable(provide)
+            return WithDefaultNullableValidator(or, provide)
+        }
+    }
 
 /**
  * Converts a non-nullable validator to a nullable validator with a default value.
@@ -58,90 +85,10 @@ fun <T : Any, S : Any> Validator<T, S>.asNullable(defaultValue: S): WithDefaultN
  * @param withDefault Function that generates the default value when input is null
  * @return A new validator that accepts null input but produces non-nullable output
  */
-fun <T : Any, S : Any> Validator<T, S>.asNullable(withDefault: () -> S): WithDefaultNullableValidator<T, S> =
-    Validator { input, context ->
-        val defaultValue = withDefault()
-        if (input == null) Success(defaultValue, context) else execute(input, context)
-    }
-
-/**
- * Adds a custom constraint to this validator.
- *
- * The constraint can check both null and non-null values before the default is applied.
- *
- * Example:
- * ```kotlin
- * val validator = Kova.string().asNullable("default")
- *     .constrain("custom") {
- *         satisfies(
- *             it.input == null || it.input.length >= 3,
- *             "Must be null or at least 3 chars"
- *         )
- *     }
- * ```
- *
- * @param id Unique identifier for the constraint
- * @param check Constraint logic that produces a [ConstraintResult]
- * @return A new validator with the constraint applied
- */
-fun <T : Any, S : Any> WithDefaultNullableValidator<T, S>.constrain(
-    id: String,
-    check: ConstraintScope<T?>.(ConstraintContext<T?>) -> ConstraintResult,
-): WithDefaultNullableValidator<T, S> = compose(ConstraintValidator(Constraint(id, check)))
-
-/**
- * Validates that the input is null.
- *
- * This constraint fails if the input is non-null.
- * Note that even though this validator has a default, this constraint checks
- * the input before the default is applied.
- *
- * Example:
- * ```kotlin
- * val validator = Kova.string().asNullable("default").isNull()
- * validator.validate(null)    // Success: "default"
- * validator.validate("hello") // Failure
- * ```
- *
- * @param message Custom error message provider
- * @return A new validator that only accepts null input
- */
-fun <T : Any, S : Any> WithDefaultNullableValidator<T, S>.isNull(
-    message: MessageProvider = Message.resource(),
-): WithDefaultNullableValidator<T, S> = constrain("kova.nullable.isNull", Constraints.isNull(message))
-
-/**
- * Validates that the input is not null.
- *
- * This constraint fails if the input is null (before the default is applied).
- *
- * Example:
- * ```kotlin
- * val validator = Kova.string().asNullable("default").notNull()
- * validator.validate("hello") // Success: "hello"
- * validator.validate(null)    // Failure: rejected before default is applied
- * ```
- *
- * @param message Custom error message provider
- * @return A new validator that rejects null input
- */
-fun <T : Any, S : Any> WithDefaultNullableValidator<T, S>.notNull(
-    message: MessageProvider = Message.resource(),
-): WithDefaultNullableValidator<T, S> = constrain("kova.nullable.notNull", Constraints.notNull(message))
-
-/**
- * Converts this validator to a standard validator with non-nullable output.
- *
- * Since this validator already produces non-nullable output (due to the default),
- * this is effectively a no-op type conversion.
- *
- * Example:
- * ```kotlin
- * val withDefault: WithDefaultNullableValidator<String, String> =
- *     Kova.string().asNullable("default")
- * val standard: Validator<String?, String> = withDefault.toNonNullable()
- * ```
- *
- * @return The same validator with standard Validator type
- */
-fun <T : Any, S : Any> WithDefaultNullableValidator<T, S>.toNonNullable(): Validator<T?, S> = map { it }
+fun <T : Any, S : Any> Validator<T, S>.asNullable(withDefault: () -> S): WithDefaultNullableValidator<T, S> {
+    val validator =
+        Validator<T?, S> { input, context ->
+            if (input == null) Success(withDefault(), context) else execute(input, context)
+        }
+    return WithDefaultNullableValidator(validator, withDefault)
+}

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
@@ -38,132 +38,9 @@ class WithDefaultNullableValidatorTest :
             }
         }
 
-        context("isNull") {
-            val isNull = Kova.nullable(0).isNull()
-
-            test("success") {
-                val result = isNull.tryValidate(null)
-                result.isSuccess().mustBeTrue()
-                result.value shouldBe 0
-            }
-
-            test("failure") {
-                val result = isNull.tryValidate(4)
-                result.isFailure().mustBeTrue()
-                result.messages.size shouldBe 1
-                result.messages[0].text shouldBe "must be null"
-            }
-
-            test("failure - min constraint violated") {
-                val result = isNull.tryValidate(2)
-                result.isFailure().mustBeTrue()
-                result.messages.size shouldBe 1
-                result.messages[0].text shouldBe "must be null"
-            }
-        }
-
-        context("isNull or nullable") {
-            val isNull = Kova.nullable(0).isNull()
-            val isNullOrMin3Max3 =
-                isNull.or(
-                    Kova
-                        .int()
-                        .min(3)
-                        .max(3)
-                        .asNullable(0),
-                )
-
-            test("success - null") {
-                val result = isNullOrMin3Max3.tryValidate(null)
-                result.isSuccess().mustBeTrue()
-                result.value shouldBe 0
-            }
-
-            test("success - 3") {
-                val result = isNullOrMin3Max3.tryValidate(3)
-                result.isSuccess().mustBeTrue()
-                result.value shouldBe 3
-            }
-
-            test("failure") {
-                val result = isNullOrMin3Max3.tryValidate(5)
-                result.isFailure().mustBeTrue()
-                result.messages.size shouldBe 1
-                result.messages[0].let {
-                    it.constraintId shouldBe "kova.or"
-                    it.text shouldBe
-                        "at least one constraint must be satisfied: [[must be null], [must be less than or equal to 3]]"
-                }
-            }
-        }
-
-        context("isNull or nonNullable") {
-            val min3 = Kova.int().min(3)
-            val max3 = Kova.int().max(3)
-            val isNullOrMin3Max3 = Kova.nullable(0).isNull().or((min3 and max3).asNullable(0))
-
-            test("success - null") {
-                val result = isNullOrMin3Max3.tryValidate(null)
-                result.isSuccess().mustBeTrue()
-                result.value shouldBe 0
-            }
-
-            test("success - non-null") {
-                val result = isNullOrMin3Max3.tryValidate(3)
-                result.isSuccess().mustBeTrue()
-                result.value shouldBe 3
-            }
-
-            test("failure - isNull and max3 constraints violated") {
-                val result = isNullOrMin3Max3.tryValidate(5)
-                result.isFailure().mustBeTrue()
-                result.messages.size shouldBe 1
-                result.messages[0].constraintId shouldBe "kova.or"
-            }
-        }
-
-        context("isNull or then") {
-            val min3 = Kova.int().min(3)
-            val min5 = Kova.int().min(5)
-            val max4 = Kova.int().max(4)
-            val isNullOrMin3OrMin5AndThenMax4 =
-                Kova
-                    .int()
-                    .asNullable(0)
-                    .isNull()
-                    .or((min3 or min5).asNullable(0))
-                    .then(max4)
-
-            test("success - isNull constraint satisfied") {
-                val result = isNullOrMin3OrMin5AndThenMax4.tryValidate(null)
-                result.isSuccess().mustBeTrue()
-                result.value shouldBe 0
-            }
-
-            test("success - min3 constraint satisfied") {
-                val result = isNullOrMin3OrMin5AndThenMax4.tryValidate(3)
-                result.isSuccess().mustBeTrue()
-                result.value shouldBe 3
-            }
-
-            test("success - max4 constraint failed") {
-                val result = isNullOrMin3OrMin5AndThenMax4.tryValidate(5)
-                result.isFailure().mustBeTrue()
-                result.messages.size shouldBe 1
-                result.messages[0].text shouldBe "must be less than or equal to 4"
-            }
-
-            test("failure - all constraints violated") {
-                val result = isNullOrMin3OrMin5AndThenMax4.tryValidate(2)
-                result.isFailure().mustBeTrue()
-                result.messages.size shouldBe 1
-                result.messages[0].constraintId shouldBe "kova.or"
-            }
-        }
-
         context("and") {
             val min3 = Kova.int().min(3)
-            val whenNotNullMin3 = Kova.nullable(3).and(min3.asNullable(0))
+            val whenNotNullMin3 = Kova.nullable(3).and(min3)
 
             test("success - non-null") {
                 val result = whenNotNullMin3.tryValidate(4)
@@ -175,7 +52,7 @@ class WithDefaultNullableValidatorTest :
                 val logs = mutableListOf<String>()
                 val result = whenNotNullMin3.tryValidate(null, config = ValidationConfig(logger = { logs.add(it) }))
                 result.isSuccess().mustBeTrue(result)
-                result.value shouldBe 0
+                result.value shouldBe 3
                 logs shouldBe listOf()
             }
 
@@ -189,7 +66,7 @@ class WithDefaultNullableValidatorTest :
 
         context("and - each List element") {
             val min3 = Kova.int().min(3)
-            val nullableMin3 = Kova.nullable(0).and(min3.asNullable(0))
+            val nullableMin3 = Kova.nullable(0).and(min3)
             val onEachNullableMin3 = Kova.list<Int?>().onEach(nullableMin3)
 
             test("success - non-null") {
@@ -211,9 +88,9 @@ class WithDefaultNullableValidatorTest :
             }
         }
 
-        context("toNonNullable") {
+        context("asNullable") {
             val min3 = Kova.int().min(3)
-            val nullableMin3 = min3.asNullable(0).toNonNullable()
+            val nullableMin3 = min3.asNullable(0)
 
             test("success - non-null") {
                 val result = nullableMin3.tryValidate(4)
@@ -236,10 +113,10 @@ class WithDefaultNullableValidatorTest :
             }
         }
 
-        context("toNonNullable - then") {
+        context("then") {
             val max5 = Kova.int().max(5)
             val min3 = Kova.int().min(3)
-            val notNullAndMin3AndMax3 = Kova.nullable(4).toNonNullable().then(min3 and max5)
+            val notNullAndMin3AndMax3 = Kova.nullable(4).then(min3 and max5)
 
             test("success") {
                 val result = notNullAndMin3AndMax3.tryValidate(4)
@@ -267,9 +144,14 @@ class WithDefaultNullableValidatorTest :
             }
         }
 
-        context("logs") {
+        context("or") {
             val min3 = Kova.int().min(3)
-            val isNullOrMin3Max3 = Kova.nullable(0).isNull().or(min3.asNullable(0))
+            val isNullOrMin3Max3 =
+                Kova
+                    .int()
+                    .max(5)
+                    .asNullable(0)
+                    .or(min3)
 
             test("success: 3") {
                 val logs = mutableListOf<String>()
@@ -277,10 +159,28 @@ class WithDefaultNullableValidatorTest :
                 val result = isNullOrMin3Max3.tryValidate(3, config = config)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 3
+                logs shouldBe listOf("Satisfied(constraintId=kova.comparable.max, root=, path=, input=3)")
+            }
+
+            test("success: 2") {
+                val logs = mutableListOf<String>()
+                val config = ValidationConfig(logger = { logs.add(it) })
+                val result = isNullOrMin3Max3.tryValidate(2, config = config)
+                result.isSuccess().mustBeTrue()
+                result.value shouldBe 2
+                logs shouldBe listOf("Satisfied(constraintId=kova.comparable.max, root=, path=, input=2)")
+            }
+
+            test("success: 6") {
+                val logs = mutableListOf<String>()
+                val config = ValidationConfig(logger = { logs.add(it) })
+                val result = isNullOrMin3Max3.tryValidate(6, config = config)
+                result.isSuccess().mustBeTrue()
+                result.value shouldBe 6
                 logs shouldBe
                     listOf(
-                        "Violated(constraintId=kova.nullable.isNull, root=, path=, input=3)",
-                        "Satisfied(constraintId=kova.comparable.min, root=, path=, input=3)",
+                        "Violated(constraintId=kova.comparable.max, root=, path=, input=6)",
+                        "Satisfied(constraintId=kova.comparable.min, root=, path=, input=6)",
                     )
             }
 
@@ -290,10 +190,7 @@ class WithDefaultNullableValidatorTest :
                 val result = isNullOrMin3Max3.tryValidate(null, config = config)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0
-                logs shouldBe
-                    listOf(
-                        "Satisfied(constraintId=kova.nullable.isNull, root=, path=, input=null)",
-                    )
+                logs shouldBe listOf()
             }
         }
     })


### PR DESCRIPTION
## Summary

- Converted `WithDefaultNullableValidator` from a type alias to a dedicated interface
- The `and` and `or` operators now automatically propagate the default value provider, eliminating the need for explicit `asNullable()` calls when composing validators
- Removed extension functions (`constrain`, `isNull`, `notNull`, `toNonNullable`) that are no longer needed with the interface-based approach
- Updated tests to reflect the simplified composition API

## Key Changes

**Before:**
```kotlin
val validator = Kova.nullable(3).and(min3.asNullable(0))
```

**After:**
```kotlin
val validator = Kova.nullable(3).and(min3) // default value propagated automatically
```

## Test plan

- [x] All existing tests pass with updated composition syntax
- [x] Removed tests for deprecated extension functions (`isNull`, `notNull`, `toNonNullable`)
- [x] Verified `and` and `or` operators properly propagate default values
- [x] Code formatting applied via spotlessApply

🤖 Generated with [Claude Code](https://claude.com/claude-code)