### PR TITLE
Refactor logging to use structured LogEntry types

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
@@ -35,14 +35,24 @@ fun <T> ConstraintValidator(constraint: Constraint<T>): ConstraintValidator<T> =
         when (val result = constraint.apply(constraintContext)) {
             is ConstraintResult.Satisfied -> {
                 context.log {
-                    "Satisfied(constraintId=${constraint.id}, root=${context.root}, path=${context.path.fullName}, input=$input)"
+                    LogEntry.Satisfied(
+                        constraintId = constraint.id,
+                        root = context.root,
+                        path = context.path.fullName,
+                        input = input,
+                    )
                 }
                 ValidationResult.Success(input, context)
             }
 
             is ConstraintResult.Violated -> {
                 context.log {
-                    "Violated(constraintId=${constraint.id}, root=${context.root}, path=${context.path.fullName}, input=$input)"
+                    LogEntry.Violated(
+                        constraintId = constraint.id,
+                        root = context.root,
+                        path = context.path.fullName,
+                        input = input,
+                    )
                 }
                 ValidationResult.Failure(listOf(result.message))
             }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
@@ -40,7 +40,7 @@ data class ValidationContext(
  */
 data class ValidationConfig(
     val failFast: Boolean = false,
-    val logger: ((String) -> Unit)? = null,
+    val logger: ((LogEntry) -> Unit)? = null,
 )
 
 /**
@@ -228,7 +228,7 @@ fun <T> ValidationContext.createConstraintContext(
  *
  * @param block Lambda that generates the log message (only called if logger is configured)
  */
-fun ValidationContext.log(block: () -> String) {
+fun ValidationContext.log(block: () -> LogEntry) {
     config.logger?.invoke(block())
 }
 
@@ -271,4 +271,20 @@ data class Path(
         if (obj === target) return true
         return parent?.containsObject(target) ?: false
     }
+}
+
+sealed interface LogEntry {
+    data class Satisfied(
+        val constraintId: String,
+        val root: String,
+        val path: String,
+        val input: Any?,
+    ) : LogEntry
+
+    data class Violated(
+        val constraintId: String,
+        val root: String,
+        val path: String,
+        val input: Any?,
+    ) : LogEntry
 }

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
@@ -279,23 +279,31 @@ class NullableValidatorTest :
             val isNullOrMin3Max3 = Kova.nullable<Int>().isNull().or(min3)
 
             test("success: 3") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val config = ValidationConfig(logger = { logs.add(it) })
                 val result = isNullOrMin3Max3.tryValidate(3, config = config)
                 result.isSuccess().mustBeTrue()
                 logs shouldBe
                     listOf(
-                        "Violated(constraintId=kova.nullable.isNull, root=, path=, input=3)",
-                        "Satisfied(constraintId=kova.comparable.min, root=, path=, input=3)",
+                        LogEntry.Violated(constraintId = "kova.nullable.isNull", root = "", path = "", input = 3),
+                        LogEntry.Satisfied(constraintId = "kova.comparable.min", root = "", path = "", input = 3),
                     )
             }
 
             test("success: null") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val config = ValidationConfig(logger = { logs.add(it) })
                 val result = isNullOrMin3Max3.tryValidate(null, config = config)
                 result.isSuccess().mustBeTrue()
-                logs shouldBe listOf("Satisfied(constraintId=kova.nullable.isNull, root=, path=, input=null)")
+                logs shouldBe
+                    listOf(
+                        LogEntry.Satisfied(
+                            constraintId = "kova.nullable.isNull",
+                            root = "",
+                            path = "",
+                            input = null,
+                        ),
+                    )
             }
         }
     })

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
@@ -160,27 +160,27 @@ class ValidatorTest :
                 Kova.string().trim().then(Kova.string().min(3).max(5))
 
             test("success") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val result = validator.tryValidate(" abcde ", ValidationConfig(logger = { logs.add(it) }))
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "abcde"
 
                 logs shouldBe
                     listOf(
-                        "Satisfied(constraintId=kova.string.min, root=, path=, input=abcde)",
-                        "Satisfied(constraintId=kova.string.max, root=, path=, input=abcde)",
+                        LogEntry.Satisfied(constraintId = "kova.string.min", root = "", path = "", input = "abcde"),
+                        LogEntry.Satisfied(constraintId = "kova.string.max", root = "", path = "", input = "abcde"),
                     )
             }
 
             test("failure") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val result = validator.tryValidate(" ab ", ValidationConfig(logger = { logs.add(it) }))
                 result.isFailure().mustBeTrue()
 
                 logs shouldBe
                     listOf(
-                        "Violated(constraintId=kova.string.min, root=, path=, input=ab)",
-                        "Satisfied(constraintId=kova.string.max, root=, path=, input=ab)",
+                        LogEntry.Violated(constraintId = "kova.string.min", root = "", path = "", input = "ab"),
+                        LogEntry.Satisfied(constraintId = "kova.string.max", root = "", path = "", input = "ab"),
                     )
             }
         }

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
@@ -49,7 +49,7 @@ class WithDefaultNullableValidatorTest :
             }
 
             test("success - null") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val result = whenNotNullMin3.tryValidate(null, config = ValidationConfig(logger = { logs.add(it) }))
                 result.isSuccess().mustBeTrue(result)
                 result.value shouldBe 3
@@ -154,38 +154,54 @@ class WithDefaultNullableValidatorTest :
                     .or(min3)
 
             test("success: 3") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val config = ValidationConfig(logger = { logs.add(it) })
                 val result = isNullOrMin3Max3.tryValidate(3, config = config)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 3
-                logs shouldBe listOf("Satisfied(constraintId=kova.comparable.max, root=, path=, input=3)")
+                logs shouldBe
+                    listOf(
+                        LogEntry.Satisfied(
+                            constraintId = "kova.comparable.max",
+                            root = "",
+                            path = "",
+                            input = 3,
+                        ),
+                    )
             }
 
             test("success: 2") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val config = ValidationConfig(logger = { logs.add(it) })
                 val result = isNullOrMin3Max3.tryValidate(2, config = config)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 2
-                logs shouldBe listOf("Satisfied(constraintId=kova.comparable.max, root=, path=, input=2)")
+                logs shouldBe
+                    listOf(
+                        LogEntry.Satisfied(
+                            constraintId = "kova.comparable.max",
+                            root = "",
+                            path = "",
+                            input = 2,
+                        ),
+                    )
             }
 
             test("success: 6") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val config = ValidationConfig(logger = { logs.add(it) })
                 val result = isNullOrMin3Max3.tryValidate(6, config = config)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 6
                 logs shouldBe
                     listOf(
-                        "Violated(constraintId=kova.comparable.max, root=, path=, input=6)",
-                        "Satisfied(constraintId=kova.comparable.min, root=, path=, input=6)",
+                        LogEntry.Violated(constraintId = "kova.comparable.max", root = "", path = "", input = 6),
+                        LogEntry.Satisfied(constraintId = "kova.comparable.min", root = "", path = "", input = 6),
                     )
             }
 
             test("success: null") {
-                val logs = mutableListOf<String>()
+                val logs = mutableListOf<LogEntry>()
                 val config = ValidationConfig(logger = { logs.add(it) })
                 val result = isNullOrMin3Max3.tryValidate(null, config = config)
                 result.isSuccess().mustBeTrue()


### PR DESCRIPTION
## Summary
- Introduced `LogEntry` sealed interface with `Satisfied` and `Violated` data classes to replace string-based logging
- Updated `ValidationConfig.logger` signature from `((String) -> Unit)?` to `((LogEntry) -> Unit)?`
- Refactored constraint validation logging to use structured LogEntry objects instead of string interpolation
- Updated all test cases to assert against LogEntry objects for improved type safety

## Test plan
- [x] Existing tests updated to work with LogEntry types
- [x] All tests pass with the new structured logging approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)