### PR TITLE
Fix: preserve input values through validation failures

### DIFF
--- a/example/src/test/kotlin/example/MainTest.kt
+++ b/example/src/test/kotlin/example/MainTest.kt
@@ -23,7 +23,7 @@ class MainTest :
                 val user = User("", -1)
                 val result = UserSchema.tryValidate(user)
 
-                result.shouldBeInstanceOf<ValidationResult.Failure>()
+                result.shouldBeInstanceOf<ValidationResult.Failure<*>>()
                 val messages = result.messages.map { it.text }
                 messages.size shouldBe 3
                 messages.any { it.contains("at least 1 characters") } shouldBe true
@@ -35,7 +35,7 @@ class MainTest :
                 val user = User("Bob", 150)
                 val result = UserSchema.tryValidate(user)
 
-                result.shouldBeInstanceOf<ValidationResult.Failure>()
+                result.shouldBeInstanceOf<ValidationResult.Failure<*>>()
                 val messages = result.messages.map { it.text }
                 messages.any { it.contains("less than or equal to 120") } shouldBe true
             }
@@ -52,7 +52,7 @@ class MainTest :
             test("failure - invalid inputs") {
                 val result = UserSchema.bind("", -1).tryCreate()
 
-                result.shouldBeInstanceOf<ValidationResult.Failure>()
+                result.shouldBeInstanceOf<ValidationResult.Failure<*>>()
                 val messages = result.messages.map { it.text }
                 messages.size shouldBe 3
                 messages.any { it.contains("at least 1 characters") } shouldBe true
@@ -72,7 +72,7 @@ class MainTest :
             test("failure - non-numeric string") {
                 val result = AgeSchema.bind("not a number").tryCreate()
 
-                result.shouldBeInstanceOf<ValidationResult.Failure>()
+                result.shouldBeInstanceOf<ValidationResult.Failure<*>>()
                 val messages = result.messages.map { it.text }
                 messages.any { it.contains("must be a valid integer") } shouldBe true
             }
@@ -80,7 +80,7 @@ class MainTest :
             test("failure - age out of range") {
                 val result = AgeSchema.bind("150").tryCreate()
 
-                result.shouldBeInstanceOf<ValidationResult.Failure>()
+                result.shouldBeInstanceOf<ValidationResult.Failure<*>>()
                 val messages = result.messages.map { it.text }
                 messages.any { it.contains("less than or equal to 120") } shouldBe true
             }
@@ -97,7 +97,7 @@ class MainTest :
             test("failure - invalid name and non-numeric age") {
                 val result = PersonSchema.bind("", "not number").tryCreate()
 
-                result.shouldBeInstanceOf<ValidationResult.Failure>()
+                result.shouldBeInstanceOf<ValidationResult.Failure<*>>()
                 val messages = result.messages.map { it.text }
                 messages.size shouldBe 3
                 messages.any { it.contains("at least 1 characters") } shouldBe true
@@ -108,7 +108,7 @@ class MainTest :
             test("failure - blank name") {
                 val result = PersonSchema.bind("   ", "25").tryCreate()
 
-                result.shouldBeInstanceOf<ValidationResult.Failure>()
+                result.shouldBeInstanceOf<ValidationResult.Failure<*>>()
                 val messages = result.messages.map { it.text }
                 messages.any { it.contains("must not be blank") } shouldBe true
             }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/CollectionValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/CollectionValidator.kt
@@ -112,7 +112,7 @@ fun <C : Collection<*>> CollectionValidator<C>.length(
 fun <E, C : Collection<E>> CollectionValidator<C>.onEach(validator: Validator<E, *>) =
     constrain("kova.collection.onEach") { constraintContext ->
         val validationContext = constraintContext.validationContext
-        val failures = mutableListOf<ValidationResult.Failure>()
+        val failures = mutableListOf<ValidationResult.Failure<*>>()
         for ((i, element) in constraintContext.input.withIndex()) {
             val path = "[$i]<collection element>"
             val result = validator.execute(element, validationContext.appendPath(path))

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
@@ -54,7 +54,7 @@ fun <T> ConstraintValidator(constraint: Constraint<T>): ConstraintValidator<T> =
                         input = input,
                     )
                 }
-                ValidationResult.Failure(listOf(result.message))
+                ValidationResult.Failure(Input.Some(input), listOf(result.message))
             }
         }
     }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/IdentityValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/IdentityValidator.kt
@@ -145,7 +145,13 @@ fun <T> IdentityValidator<T>.chain(next: IdentityValidator<T>): IdentityValidato
                 if (context.failFast) {
                     result
                 } else {
-                    result + next.execute(input, context)
+                    when (val v = result.value) {
+                        is Input.Unknown -> {
+                            val value = v.value as? T
+                            if (value != null) result + next.execute(value, context) else result
+                        }
+                        is Input.Some -> result + next.execute(v.value, context)
+                    }
                 }
             }
         }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/MapValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/MapValidator.kt
@@ -179,7 +179,7 @@ private fun <K, V, T> ConstraintScope<Map<K, V>>.validateOnEach(
     validate: (Map.Entry<K, V>, ValidationContext) -> ValidationResult<T>,
 ): ConstraintResult {
     val validationContext = context.validationContext
-    val failures = mutableListOf<ValidationResult.Failure>()
+    val failures = mutableListOf<ValidationResult.Failure<*>>()
     for (entry in context.input.entries) {
         val result = validate(entry, validationContext)
         if (result.isFailure()) {

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/Message.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/Message.kt
@@ -128,7 +128,7 @@ sealed interface Message {
     data class Collection(
         /** The message context containing the constraint ID and validation state for the collection constraint */
         override val context: MessageContext<*>,
-        val elements: List<ValidationResult.Failure>,
+        val elements: List<ValidationResult.Failure<*>>,
     ) : Message {
         override val text: String get() = Resource(context).text
         override val constraintId: String
@@ -167,8 +167,8 @@ sealed interface Message {
     data class Or(
         /** The message context containing the constraint ID (typically "kova.or") and validation state */
         override val context: MessageContext<*>,
-        val first: ValidationResult.Failure,
-        val second: ValidationResult.Failure,
+        val first: ValidationResult.Failure<*>,
+        val second: ValidationResult.Failure<*>,
     ) : Message {
         override val text: String get() = Resource(context).text
         override val constraintId: String

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
@@ -117,7 +117,7 @@ fun <T : Any, S : Any> NullableValidator<T, S>.notNull(message: MessageProvider 
  *
  * @return A validator that rejects null and produces non-nullable output
  */
-fun <T : Any, S : Any> NullableValidator<T, S>.toNonNullable(): Validator<T?, S> = notNull().map { it!! }
+inline fun <reified T : Any, reified S : Any> NullableValidator<T, S>.toNonNullable(): Validator<T?, S> = notNull().map { it!! }
 
 /**
  * Provides a default value for null inputs.
@@ -136,7 +136,7 @@ fun <T : Any, S : Any> NullableValidator<T, S>.toNonNullable(): Validator<T?, S>
  * @param defaultValue The value to use when input is null
  * @return A new validator with non-nullable output that uses the default for null inputs
  */
-fun <T : Any, S : Any> NullableValidator<T, S>.withDefault(defaultValue: S): WithDefaultNullableValidator<T, S> =
+inline fun <reified T : Any, reified S : Any> NullableValidator<T, S>.withDefault(defaultValue: S): WithDefaultNullableValidator<T, S> =
     withDefault { defaultValue }
 
 /**
@@ -157,8 +157,9 @@ fun <T : Any, S : Any> NullableValidator<T, S>.withDefault(defaultValue: S): Wit
  * @param provide Function that generates the default value
  * @return A new validator with non-nullable output that uses the provided default for null inputs
  */
-fun <T : Any, S : Any> NullableValidator<T, S>.withDefault(provide: () -> S): WithDefaultNullableValidator<T, S> =
-    WithDefaultNullableValidator(map { it ?: provide() }, provide)
+inline fun <reified T : Any, reified S : Any> NullableValidator<T, S>.withDefault(
+    noinline provide: () -> S,
+): WithDefaultNullableValidator<T, S> = WithDefaultNullableValidator(map { it ?: provide() }, provide)
 
 /**
  * Operator overload for [and]. Combines this nullable validator with a non-nullable validator.

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectFactory.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectFactory.kt
@@ -20,12 +20,12 @@ private fun <T : Any> createFailure(
 ): ValidationResult<T> {
     val result =
         (listOf(arg) + args)
-            .filterIsInstance<ValidationResult.Failure>()
+            .filterIsInstance<ValidationResult.Failure<*>>()
             .map { it as ValidationResult<Any?> }
             .reduce { a, b -> a + b }
     return when (result) {
         is ValidationResult.Success -> error("This should never happen.")
-        is ValidationResult.Failure -> result
+        is ValidationResult.Failure -> ValidationResult.Failure(Input.Unknown(null), result.messages)
     }
 }
 

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectSchema.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectSchema.kt
@@ -113,7 +113,7 @@ open class ObjectSchema<T : Any> private constructor(
             is ValidationResult.Success -> {
                 when (val result = validator.execute(pathResult.value, pathResult.context)) {
                     is ValidationResult.Success -> ValidationResult.Success(input, result.context)
-                    is ValidationResult.Failure -> result
+                    is ValidationResult.Failure -> ValidationResult.Failure(Input.Some(input), result.messages)
                 }
             }
             // If circular reference detected, terminate validation early with success

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/StringValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/StringValidator.kt
@@ -512,7 +512,7 @@ fun StringValidator.trim() = map { it.trim() }
  *
  * @return A new validator that transforms to uppercase
  */
-fun StringValidator.toUpperCase() = map { it.uppercase() }
+fun StringValidator.toUpperCase() = map { it.uppercase() } // TODO rename
 
 /**
  * Transforms the string to lowercase.
@@ -525,7 +525,7 @@ fun StringValidator.toUpperCase() = map { it.uppercase() }
  *
  * @return A new validator that transforms to lowercase
  */
-fun StringValidator.toLowerCase() = map { it.lowercase() }
+fun StringValidator.toLowerCase() = map { it.lowercase() } // TODO rename
 
 /**
  * Validates that the string can be parsed as an Int and converts it.

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
@@ -164,7 +164,7 @@ fun <T> ValidationContext.addPathChecked(
         val constraintContext = createConstraintContext(obj, "kova.circularReference")
         val messageContext = constraintContext.createMessageContext(emptyList())
         val message = Message.Text(messageContext, "Circular reference detected.")
-        return ValidationResult.Failure(listOf(message))
+        return ValidationResult.Failure(Input.Some(obj), listOf(message))
     }
     return ValidationResult.Success(obj, addPath(name, obj))
 }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/WithDefaultNullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/WithDefaultNullableValidator.kt
@@ -29,6 +29,7 @@ interface WithDefaultNullableValidator<T : Any, S : Any> : Validator<T?, S> {
     infix fun or(other: Validator<T, S>): WithDefaultNullableValidator<T, S>
 }
 
+@PublishedApi
 internal fun <T : Any, S : Any> WithDefaultNullableValidator(
     validator: Validator<T?, S>,
     provide: () -> S,

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
@@ -6,6 +6,27 @@ import io.kotest.matchers.shouldBe
 class StringValidatorTest :
     FunSpec({
 
+        context("mapping operation after failure") {
+            val validator =
+                Kova
+                    .string()
+                    .trim()
+                    .min(3)
+                    .toUpperCase()
+                    .max(3)
+
+            test("failure") {
+                val logs = mutableListOf<LogEntry>()
+                val result = validator.tryValidate("  ab  ", config = ValidationConfig(logger = { logs.add(it) }))
+                result.isFailure().mustBeTrue()
+                logs shouldBe
+                    listOf(
+                        LogEntry.Violated(constraintId = "kova.string.min", root = "", path = "", input = "ab"),
+                        LogEntry.Satisfied(constraintId = "kova.string.max", root = "", path = "", input = "AB"),
+                    )
+            }
+        }
+
         context("plus") {
             val validator = Kova.string().max(2) + Kova.string().max(3)
 


### PR DESCRIPTION
## Summary

- Introduces `Input` sealed interface to track values in validation failure cases
- Enables proper value transformation and error reporting in chained validators even when earlier constraints fail
- Allows map transformations to run on failed results in non-failFast mode

## Key Changes

- **ValidationResult.Failure** is now generic with a `value` field of type `Input<T>`
- **Input sealed interface** distinguishes between:
  - `Input.Some<T>` - Known input values with correct type information
  - `Input.Unknown` - Type-transformed or unknown values that can't be safely processed further
- **map() function** now attempts transformation even in failure cases when types align, enabling transformations like `.trim().min(3).toUpperCase().max(3)` to apply uppercase transformation even when min constraint fails
- Updated all validators to properly pass input values through failure cases
- Added test demonstrating map transformations apply after earlier constraint failures

## Test Plan

- [x] All existing tests pass
- [x] Added new test case `StringValidatorTest.kt:9-28` demonstrating map transformation on failed validation
- [x] Verified that chained validators properly track values through failures
- [x] Confirmed logging shows transformations are applied even when earlier constraints fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)