### PR TITLE
Standardize test descriptions with natural English naming

### DIFF
--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/CollectionValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/CollectionValidatorTest.kt
@@ -32,14 +32,14 @@ class CollectionValidatorTest :
                 result.value shouldBe listOf("1", "2")
             }
 
-            test("failure - too few elements") {
+            test("failure with too few elements") {
                 val result = validator.tryValidate(listOf("1"))
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
                 result.messages[0].constraintId shouldBe "kova.collection.length"
             }
 
-            test("failure - too many elements") {
+            test("failure with too many elements") {
                 val result = validator.tryValidate(listOf("1", "2", "3"))
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -113,7 +113,7 @@ class CollectionValidatorTest :
                 }
             }
 
-            test("failure - failFast is true") {
+            test("failure when failFast is true") {
                 val result = validator.tryValidate(listOf("123", "4567", "8910"), ValidationConfig(failFast = true))
                 result.isFailure().mustBeTrue()
                 result.messages[0].let {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/IdentityValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/IdentityValidatorTest.kt
@@ -94,14 +94,14 @@ class IdentityValidatorTest :
         }
 
         context("onlyIf") {
-            test("success - condition not met") {
+            test("success when condition not met") {
                 val validator = Kova.int().min(3).onlyIf { it % 2 == 0 }
                 val result = validator.tryValidate(1)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 1
             }
 
-            test("failure - condition met") {
+            test("failure when condition met") {
                 val validator = Kova.int().min(3).onlyIf { it % 2 == 0 }
                 val result = validator.tryValidate(2)
                 result.isFailure().mustBeTrue()

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaTest.kt
@@ -22,7 +22,7 @@ class KovaTest :
             }
         }
 
-        context("failFast - plus") {
+        context("failFast with plus operator") {
             val validator = Kova.string().min(3).asNullable() + Kova.string().length(4).asNullable()
 
             test("failFast = false") {
@@ -41,12 +41,12 @@ class KovaTest :
         context("boolean") {
             val validator = Kova.boolean()
 
-            test("success - true") {
+            test("success with true value") {
                 val result = validator.tryValidate(true)
                 result.isSuccess().mustBeTrue()
             }
 
-            test("success - false") {
+            test("success with false value") {
                 val result = validator.tryValidate(false)
                 result.isSuccess().mustBeTrue()
             }
@@ -73,14 +73,14 @@ class KovaTest :
                     }
                 }
 
-            test("success - null") {
+            test("success with null value") {
                 val userFactory = userSchema.bind(null, null)
                 val result = userFactory.tryCreate()
                 result.isSuccess().mustBeTrue(result.toString())
                 result.value shouldBe User(null, null)
             }
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val userFactory = userSchema.bind("", 0)
                 val result = userFactory.tryCreate()
                 result.isSuccess().mustBeTrue()
@@ -112,13 +112,13 @@ class KovaTest :
             val requestKeyIsNotNull = requestKey.then(notNull)
             val requestKeyIsNotNullAndMin3 = requestKey.then(notNullAndMin3)
 
-            test("success - requestKeyIsNotNull") {
+            test("success when requestKey is not null") {
                 val result = requestKeyIsNotNull.tryValidate(Request(mapOf("key" to "abc")))
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "abc"
             }
 
-            test("failure - requestKeyIsNotNull") {
+            test("failure when requestKey is null") {
                 val result = requestKeyIsNotNull.tryValidate(Request(mapOf()))
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -128,13 +128,13 @@ class KovaTest :
                 }
             }
 
-            test("success - requestKeyIsNotNullAndMin3") {
+            test("success when requestKey is not null and min 3") {
                 val result = requestKeyIsNotNullAndMin3.tryValidate(Request(mapOf("key" to "abc")))
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "abc"
             }
 
-            test("failure - requestKeyIsNotNullAndMin3") {
+            test("failure when requestKey constraint violated") {
                 val result = requestKeyIsNotNullAndMin3.tryValidate(Request(mapOf("key" to "ab")))
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/MapValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/MapValidatorTest.kt
@@ -70,13 +70,13 @@ class MapValidatorTest :
                 result.value shouldBe mapOf("a" to "1", "b" to "2")
             }
 
-            test("failure - too few") {
+            test("failure with too few entries") {
                 val result = validator.tryValidate(mapOf("a" to "1"))
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.map.length"
             }
 
-            test("failure - too many") {
+            test("failure with too many entries") {
                 val result = validator.tryValidate(mapOf("a" to "1", "b" to "2", "c" to "3"))
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.map.length"

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
@@ -9,45 +9,45 @@ class NullableValidatorTest :
         context("nullable") {
             val nullable = Kova.nullable<Int>()
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullable.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe null
             }
 
-            test("success - non null") {
+            test("success with non-null value") {
                 val result = nullable.tryValidate(123)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 123
             }
         }
 
-        context("withDefault - literal") {
+        context("withDefault with literal") {
             val nullable = Kova.nullable<Int>().withDefault(0)
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullable.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0
             }
 
-            test("success - non null") {
+            test("success with non-null value") {
                 val result = nullable.tryValidate(123)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 123
             }
         }
 
-        context("withDefault - lambda") {
+        context("withDefault with lambda") {
             val nullable = Kova.nullable<Int>().withDefault { 0 }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullable.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0
             }
 
-            test("success - non null") {
+            test("success with non-null value") {
                 val result = nullable.tryValidate(123)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 123
@@ -80,12 +80,12 @@ class NullableValidatorTest :
                         .max(3),
                 )
 
-            test("success - null") {
+            test("success with null value") {
                 val result = isNullOrMin3Max3.tryValidate(null)
                 result.isSuccess().mustBeTrue()
             }
 
-            test("success - 3") {
+            test("success with value 3") {
                 val result = isNullOrMin3Max3.tryValidate(3)
                 result.isSuccess().mustBeTrue()
             }
@@ -105,17 +105,17 @@ class NullableValidatorTest :
         context("isNullOr") {
             val isNullOrMin3Max3 = Kova.nullable<Int>().isNullOr({ it.min(3).max(3) })
 
-            test("success - null") {
+            test("success with null value") {
                 val result = isNullOrMin3Max3.tryValidate(null)
                 result.isSuccess().mustBeTrue()
             }
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val result = isNullOrMin3Max3.tryValidate(3)
                 result.isSuccess().mustBeTrue()
             }
 
-            test("failure - isNull and max3 constraints violated") {
+            test("failure when isNull and max3 constraints violated") {
                 val result = isNullOrMin3Max3.tryValidate(5)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -156,7 +156,7 @@ class NullableValidatorTest :
                 result.messages[0].constraintId shouldBe "kova.nullable.notNull"
             }
 
-            test("failure - min constraint violated") {
+            test("failure when min constraint violated") {
                 val result = notNullAndMin3.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -168,17 +168,17 @@ class NullableValidatorTest :
             val min3 = Kova.int().min(3)
             val nullableMin3 = Kova.nullable<Int>().and(min3)
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val result = nullableMin3.tryValidate(4)
                 result.isSuccess().mustBeTrue()
             }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullableMin3.tryValidate(null)
                 result.isSuccess().mustBeTrue()
             }
 
-            test("failure - min3 constraint violated") {
+            test("failure when min3 constraint violated") {
                 val result = nullableMin3.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -191,17 +191,17 @@ class NullableValidatorTest :
             val nullableMin3 = Kova.nullable<Int>().and(min3)
             val onEachNullableMin3 = Kova.list<Int?>().onEach(nullableMin3)
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val result = onEachNullableMin3.tryValidate(listOf(4, 5))
                 result.isSuccess().mustBeTrue()
             }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = onEachNullableMin3.tryValidate(listOf(null, null))
                 result.isSuccess().mustBeTrue()
             }
 
-            test("failure - min3　constraint violated") {
+            test("failure when min3 constraint violated") {
                 val result = onEachNullableMin3.tryValidate(listOf(2, null))
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -213,21 +213,21 @@ class NullableValidatorTest :
             val min3 = Kova.int().min(3)
             val nullableMin3 = min3.asNullable().toNonNullable()
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val result = nullableMin3.tryValidate(4)
                 result.isSuccess().mustBeTrue()
                 val value: Int = result.value // The type is "Int" instead of "Int?"
                 value shouldBe 4
             }
 
-            test("failure - null") {
+            test("failure with null value") {
                 val result = nullableMin3.tryValidate(null)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
                 result.messages[0].constraintId shouldBe "kova.nullable.notNull"
             }
 
-            test("failure - min3 constraint is violated") {
+            test("failure when min3 constraint is violated") {
                 val result = nullableMin3.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -243,21 +243,21 @@ class NullableValidatorTest :
                 result.isSuccess().mustBeTrue()
             }
 
-            test("failure - notNull constraint is violated") {
+            test("failure when notNull constraint is violated") {
                 val result = notNullAndMin3AndMax3.tryValidate(null)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
                 result.messages[0].constraintId shouldBe "kova.nullable.notNull"
             }
 
-            test("failure - min3 constraint is violated") {
+            test("failure when min3 constraint is violated") {
                 val result = notNullAndMin3AndMax3.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
                 result.messages[0].constraintId shouldBe "kova.comparable.min"
             }
 
-            test("failure - max5 constraint violated") {
+            test("failure when max5 constraint violated") {
                 val result = notNullAndMin3AndMax3.tryValidate(6)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NumberValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NumberValidatorTest.kt
@@ -28,18 +28,18 @@ class NumberValidatorTest :
         context("or") {
             val validator = (Kova.int().max(2) or Kova.int().max(3)).min(1)
 
-            test("success : 2") {
+            test("success with value 2") {
                 val result = validator.tryValidate(2)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 2
             }
-            test("success : 3") {
+            test("success with value 3") {
                 val result = validator.tryValidate(3)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 3
             }
 
-            test("failure : 4") {
+            test("failure with value 4") {
                 val result = validator.tryValidate(4)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -96,13 +96,13 @@ class NumberValidatorTest :
         context("positive with double") {
             val validator = Kova.double().positive()
 
-            test("success") {
+            test("success with positive number") {
                 val result = validator.tryValidate(0.1)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0.1
             }
 
-            test("failure") {
+            test("failure with negative number") {
                 val result = validator.tryValidate(-0.1)
                 result.isFailure().mustBeTrue()
                 result.messages[0].constraintId shouldBe "kova.number.positive"
@@ -140,13 +140,13 @@ class NumberValidatorTest :
         context("negative with double") {
             val validator = Kova.double().negative()
 
-            test("success") {
+            test("success with negative number") {
                 val result = validator.tryValidate(-0.1)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe -0.1
             }
 
-            test("failure") {
+            test("failure with positive number") {
                 val result = validator.tryValidate(0.1)
                 result.isFailure().mustBeTrue()
                 result.messages[0].constraintId shouldBe "kova.number.negative"
@@ -190,13 +190,13 @@ class NumberValidatorTest :
                 result.value shouldBe 0.0
             }
 
-            test("success with negative") {
+            test("success with negative number") {
                 val result = validator.tryValidate(-0.1)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe -0.1
             }
 
-            test("failure with positive") {
+            test("failure with positive number") {
                 val result = validator.tryValidate(0.1)
                 result.isFailure().mustBeTrue()
                 result.messages[0].constraintId shouldBe "kova.number.notPositive"
@@ -234,7 +234,7 @@ class NumberValidatorTest :
         context("gt with double") {
             val validator = Kova.double().gt(5.5)
 
-            test("success") {
+            test("success with value greater than threshold") {
                 val result = validator.tryValidate(5.6)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 5.6
@@ -290,7 +290,7 @@ class NumberValidatorTest :
                 result.value shouldBe 5.5
             }
 
-            test("failure") {
+            test("failure with value less than threshold") {
                 val result = validator.tryValidate(5.4)
                 result.isFailure().mustBeTrue()
                 result.messages[0].constraintId shouldBe "kova.comparable.gte"
@@ -328,7 +328,7 @@ class NumberValidatorTest :
         context("lt with double") {
             val validator = Kova.double().lt(5.5)
 
-            test("success") {
+            test("success with value less than threshold") {
                 val result = validator.tryValidate(5.4)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 5.4
@@ -384,7 +384,7 @@ class NumberValidatorTest :
                 result.value shouldBe 5.5
             }
 
-            test("failure") {
+            test("failure with value greater than threshold") {
                 val result = validator.tryValidate(5.6)
                 result.isFailure().mustBeTrue()
                 result.messages[0].constraintId shouldBe "kova.comparable.lte"

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectFactoryTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectFactoryTest.kt
@@ -9,13 +9,13 @@ class ObjectFactoryTest :
     FunSpec({
 
         context("FunctionDesc") {
-            test("KParameter available") {
+            test("success when KParameter is available") {
                 val desc = FunctionDesc("User", mapOf(0 to "name", 1 to "age"))
                 desc[0] shouldBe "name"
                 desc[1] shouldBe "age"
             }
 
-            test("KParameter unavailable") {
+            test("success when KParameter is unavailable") {
                 val desc = FunctionDesc("", emptyMap())
                 desc[0] shouldBe "param0"
                 desc[1] shouldBe "param1"
@@ -43,14 +43,14 @@ class ObjectFactoryTest :
                     }
                 }
 
-            test("success - null") {
+            test("success with null values") {
                 val userFactory = userSchema.bind(null, null)
                 val result = userFactory.tryCreate()
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe User("", 0)
             }
 
-            test("success - non-null") {
+            test("success with non-null values") {
                 val userFactory = userSchema.bind("abc", 10)
                 val result = userFactory.tryCreate()
                 result.isSuccess().mustBeTrue()
@@ -74,20 +74,20 @@ class ObjectFactoryTest :
                         }
                 }
 
-            test("success - tryCreate") {
+            test("success when using tryCreate") {
                 val factory = userSchema.bind(1)
                 val result = factory.tryCreate()
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe User(1)
             }
 
-            test("success - create") {
+            test("success when using create") {
                 val factory = userSchema.bind(1)
                 val user = factory.create()
                 user shouldBe User(1)
             }
 
-            test("failure - tryCreate") {
+            test("failure when using tryCreate") {
                 val factory = userSchema.bind(-1)
                 val result = factory.tryCreate()
                 result.isFailure().mustBeTrue()
@@ -98,7 +98,7 @@ class ObjectFactoryTest :
                 message.constraintId shouldBe "kova.comparable.min"
             }
 
-            test("failure - create") {
+            test("failure when using create") {
                 val factory = userSchema.bind(-1)
                 val ex =
                     shouldThrow<ValidationException> {
@@ -148,7 +148,7 @@ class ObjectFactoryTest :
                 result.messages.size shouldBe 2
             }
 
-            test("failure - failFast is true") {
+            test("failure when failFast is true") {
                 val userFactory = userSchema.bind(0, "")
                 val result = userFactory.tryCreate(ValidationConfig(failFast = true))
                 result.isFailure().mustBeTrue()
@@ -156,7 +156,7 @@ class ObjectFactoryTest :
             }
         }
 
-        context("2 args - generic validator") {
+        context("2 args with generic validator") {
             data class User(
                 val id: Int,
                 val name: String,
@@ -182,7 +182,7 @@ class ObjectFactoryTest :
             }
         }
 
-        context("2 args - nested factory") {
+        context("2 args with nested factory") {
             data class Age(
                 val value: Int,
             )

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectSchemaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectSchemaTest.kt
@@ -58,7 +58,7 @@ class ObjectSchemaTest :
                 result.value shouldBe user
             }
 
-            test("failure - 1 rule violated") {
+            test("failure with 1 rule violated") {
                 val user = User(2, "too-long-name")
                 val result = userSchema.tryValidate(user)
                 result.isFailure().mustBeTrue()
@@ -70,7 +70,7 @@ class ObjectSchemaTest :
                 }
             }
 
-            test("failure - 2 rules violated") {
+            test("failure with 2 rules violated") {
                 val user = User(0, "too-long-name")
                 val result = userSchema.tryValidate(user)
                 result.isFailure().mustBeTrue()
@@ -149,14 +149,14 @@ class ObjectSchemaTest :
                     val name = User::name { it.min(1).max(10) }
                 }.asNullable()
 
-            test("success - non null") {
+            test("success with non-null value") {
                 val user = User(1, "abc")
                 val result = validator.tryValidate(user)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe user
             }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = validator.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe null
@@ -178,7 +178,7 @@ class ObjectSchemaTest :
                 result.value shouldBe user
             }
 
-            test("failure - 1 constraint violated") {
+            test("failure with 1 constraint violated") {
                 val user = User(2, "too-long-name")
                 val result = userSchema.tryValidate(user)
                 result.isFailure().mustBeTrue()
@@ -190,7 +190,7 @@ class ObjectSchemaTest :
                 }
             }
 
-            test("failure - 2 constraints violated") {
+            test("failure with 2 constraints violated") {
                 val user = User(0, "too-long-name")
                 val result = userSchema.tryValidate(user)
                 result.isFailure().mustBeTrue()
@@ -272,21 +272,21 @@ class ObjectSchemaTest :
                     val address = Employee::address { addressSchema }
                 }
 
-            test("success - country is US") {
+            test("success when country is US") {
                 val employee = Employee(1, "abc", Address(1, Street(1, "def"), country = "US", postalCode = "12345678"))
                 val result = employeeSchema.tryValidate(employee)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe employee
             }
 
-            test("success - country is not US") {
+            test("success when country is not US") {
                 val employee = Employee(1, "abc", Address(1, Street(1, "def"), country = "JP", postalCode = "12345"))
                 val result = employeeSchema.tryValidate(employee)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe employee
             }
 
-            test("failure - country is US") {
+            test("failure when country is US") {
                 val employee =
                     Employee(1, "abc", Address(1, Street(1, "def"), country = "US", postalCode = "123456789"))
                 val result = employeeSchema.tryValidate(employee)
@@ -299,7 +299,7 @@ class ObjectSchemaTest :
                 }
             }
 
-            test("failure - country is not US") {
+            test("failure when country is not US") {
                 val employee =
                     Employee(1, "abc", Address(1, Street(1, "def"), country = "JP", postalCode = "123456789"))
                 val result = employeeSchema.tryValidate(employee)
@@ -346,14 +346,14 @@ class ObjectSchemaTest :
                 result.value shouldBe person
             }
 
-            test("success - nullable") {
+            test("success with nullable values") {
                 val person = Person(1, null, null, null)
                 val result = personSchema.tryValidate(person)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe person
             }
 
-            test("failure - isNotNull") {
+            test("failure when not null constraint violated") {
                 val person = Person(1, null, null, null)
                 val result = personSchema2.tryValidate(person)
                 result.isFailure().mustBeTrue()
@@ -387,7 +387,7 @@ class ObjectSchemaTest :
                 result.isSuccess().mustBeTrue()
             }
 
-            test("failure - children size > 3") {
+            test("failure when children size exceeds 3") {
                 val node = Node(listOf(Node(), Node(), Node(listOf(Node(), Node(), Node(), Node()))))
                 val result = nodeSchema.tryValidate(node)
                 result.isFailure().mustBeTrue()
@@ -396,7 +396,7 @@ class ObjectSchemaTest :
                     "Some elements do not satisfy the constraint: [Collection (size 4) must have at most 3 elements]"
             }
 
-            test("failure - grand children size > 3") {
+            test("failure when grandchildren size exceeds 3") {
                 val node = Node(listOf(Node(), Node(), Node(listOf(Node(listOf(Node(), Node(), Node(), Node()))))))
                 val result = nodeSchema.tryValidate(node)
                 result.isFailure().mustBeTrue()
@@ -418,7 +418,7 @@ class ObjectSchemaTest :
                     val next = NodeWithValue::next { it.and(this) }
                 }
 
-            test("circular reference detected - validation succeeds without error") {
+            test("success when circular reference detected") {
                 val node1 = NodeWithValue(10, null)
                 val node2 = NodeWithValue(20, node1)
                 node1.next = node2 // Create circular reference: node1 -> node2 -> node1
@@ -427,7 +427,7 @@ class ObjectSchemaTest :
                 result.isSuccess().mustBeTrue()
             }
 
-            test("non-circular nested objects - all valid") {
+            test("success with non-circular nested objects") {
                 val node4 = NodeWithValue(40, null)
                 val node3 = NodeWithValue(30, node4)
                 val node2 = NodeWithValue(20, node3)
@@ -437,7 +437,7 @@ class ObjectSchemaTest :
                 result.isSuccess().mustBeTrue()
             }
 
-            test("constraint violation in nested object") {
+            test("failure when constraint violated in nested object") {
                 val node3 = NodeWithValue(150, null) // Invalid: > 100
                 val node2 = NodeWithValue(20, node3)
                 val node1 = NodeWithValue(10, node2)
@@ -449,7 +449,7 @@ class ObjectSchemaTest :
                 result.messages[0].constraintId shouldBe "kova.comparable.max"
             }
 
-            test("constraint violation in root object") {
+            test("failure when constraint violated in root object") {
                 val node2 = NodeWithValue(20, null)
                 val node1 = NodeWithValue(-5, node2) // Invalid: < 0
 
@@ -461,7 +461,7 @@ class ObjectSchemaTest :
             }
 
             // To avoid StackOverflowError, use 'shouldBeEqual' instead of 'shouldBe'
-            test("circular reference with constraint violation - stops before revisiting") {
+            test("failure when circular reference has constraint violation") {
                 val node1 = NodeWithValue(200, null) // Invalid: > 100
                 val node2 = NodeWithValue(20, node1)
                 node1.next = node2 // Create circular reference

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
@@ -66,13 +66,13 @@ class StringValidatorTest :
         context("or") {
             val validator = (Kova.string().isInt() or Kova.literal("zero")).toUppercase()
 
-            test("success - int") {
+            test("success with int value") {
                 val result = validator.tryValidate("1")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "1"
             }
 
-            test("success - literal") {
+            test("success with literal value") {
                 val result = validator.tryValidate("zero")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "ZERO"
@@ -189,11 +189,11 @@ class StringValidatorTest :
         context("blank") {
             val blank = Kova.string().blank()
 
-            test("success - empty string") {
+            test("success with empty string") {
                 val result = blank.tryValidate("")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - whitespace only") {
+            test("success with whitespace only") {
                 val result = blank.tryValidate("   ")
                 result.isSuccess().mustBeTrue()
             }
@@ -240,12 +240,12 @@ class StringValidatorTest :
                 val result = empty.tryValidate("")
                 result.isSuccess().mustBeTrue()
             }
-            test("failure - with content") {
+            test("failure with content") {
                 val result = empty.tryValidate("ab")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.empty"
             }
-            test("failure - whitespace only") {
+            test("failure with whitespace only") {
                 val result = empty.tryValidate("   ")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.empty"
@@ -369,74 +369,74 @@ class StringValidatorTest :
         context("email") {
             val email = Kova.string().email()
 
-            test("success - simple email") {
+            test("success with simple email") {
                 val result = email.tryValidate("user@example.com")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - with dots") {
+            test("success with dots") {
                 val result = email.tryValidate("first.last@example.com")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - with plus") {
+            test("success with plus sign") {
                 val result = email.tryValidate("user+tag@example.com")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - with hyphen in domain") {
+            test("success with hyphen in domain") {
                 val result = email.tryValidate("user@my-domain.com")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - with subdomain") {
+            test("success with subdomain") {
                 val result = email.tryValidate("user@mail.example.com")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - with numbers") {
+            test("success with numbers") {
                 val result = email.tryValidate("user123@example.com")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - with underscore") {
+            test("success with underscore") {
                 val result = email.tryValidate("user_name@example.com")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - case insensitive") {
+            test("success with case insensitive") {
                 val result = email.tryValidate("User@Example.COM")
                 result.isSuccess().mustBeTrue()
             }
-            test("failure - starts with dot") {
+            test("failure when starts with dot") {
                 val result = email.tryValidate(".user@example.com")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
             }
-            test("failure - consecutive dots") {
+            test("failure with consecutive dots") {
                 val result = email.tryValidate("user..name@example.com")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
             }
-            test("failure - ends with dot before @") {
+            test("failure when ends with dot before @") {
                 val result = email.tryValidate("user.@example.com")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
             }
-            test("failure - no @") {
+            test("failure with no @ symbol") {
                 val result = email.tryValidate("userexample.com")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
             }
-            test("failure - no domain") {
+            test("failure with no domain") {
                 val result = email.tryValidate("user@")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
             }
-            test("failure - no local part") {
+            test("failure with no local part") {
                 val result = email.tryValidate("@example.com")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
             }
-            test("failure - no TLD") {
+            test("failure with no TLD") {
                 val result = email.tryValidate("user@example")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
             }
-            test("failure - spaces") {
+            test("failure with spaces") {
                 val result = email.tryValidate("user name@example.com")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.email"
@@ -566,17 +566,17 @@ class StringValidatorTest :
         context("isBoolean") {
             val isBoolean = Kova.string().isBoolean()
 
-            test("success - true") {
+            test("success with true") {
                 val result = isBoolean.tryValidate("true")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "true"
             }
-            test("success - false") {
+            test("success with false") {
                 val result = isBoolean.tryValidate("false")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "false"
             }
-            test("false - case sensitive") {
+            test("failure with case sensitive mismatch") {
                 val result = isBoolean.tryValidate("TRUE")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.isBoolean"
@@ -591,12 +591,12 @@ class StringValidatorTest :
         context("toBoolean") {
             val toBoolean = Kova.string().toBoolean()
 
-            test("success - true") {
+            test("success with true") {
                 val result = toBoolean.tryValidate("true")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe true
             }
-            test("success - false") {
+            test("success with false") {
                 val result = toBoolean.tryValidate("false")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe false
@@ -721,7 +721,7 @@ class StringValidatorTest :
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "HELLO"
             }
-            test("success - empty string") {
+            test("success with empty string") {
                 val result = uppercase.tryValidate("")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe ""
@@ -741,7 +741,7 @@ class StringValidatorTest :
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
-            test("success - empty string") {
+            test("success with empty string") {
                 val result = lowercase.tryValidate("")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe ""
@@ -780,7 +780,7 @@ class StringValidatorTest :
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "1"
             }
-            test("failure - null") {
+            test("failure with null value") {
                 val result = max1.tryValidate(null)
                 result.isFailure().mustBeTrue()
             }
@@ -803,22 +803,22 @@ class StringValidatorTest :
                     }
                 }
 
-            test("success - true") {
+            test("success with true") {
                 val result = stringBools.tryValidate("true")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe true
             }
-            test("success - 1") {
+            test("success with value 1") {
                 val result = stringBools.tryValidate("1")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe true
             }
-            test("success - false") {
+            test("success with false") {
                 val result = stringBools.tryValidate("false")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe false
             }
-            test("success - 0") {
+            test("success with value 0") {
                 val result = stringBools.tryValidate("0")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe false
@@ -834,37 +834,37 @@ class StringValidatorTest :
         context("trim") {
             val trim = Kova.string().trim()
 
-            test("success - trimming leading whitespace") {
+            test("success when trimming leading whitespace") {
                 val result = trim.tryValidate("  hello")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("success - trimming trailing whitespace") {
+            test("success when trimming trailing whitespace") {
                 val result = trim.tryValidate("hello  ")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("success - trimming both sides") {
+            test("success when trimming both sides") {
                 val result = trim.tryValidate("  hello  ")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("success - no whitespace to trim") {
+            test("success with no whitespace to trim") {
                 val result = trim.tryValidate("hello")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("success - empty string") {
+            test("success with empty string") {
                 val result = trim.tryValidate("")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe ""
             }
 
-            test("success - only whitespace") {
+            test("success with only whitespace") {
                 val result = trim.tryValidate("   ")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe ""
@@ -874,19 +874,19 @@ class StringValidatorTest :
         context("trim with constraints") {
             val trimMin3 = Kova.string().trim().min(3)
 
-            test("success - trimmed value meets constraint") {
+            test("success when trimmed value meets constraint") {
                 val result = trimMin3.tryValidate("  hello  ")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("failure - trimmed value violates constraint") {
+            test("failure when trimmed value violates constraint") {
                 val result = trimMin3.tryValidate("  hi  ")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.min"
             }
 
-            test("failure - whitespace only becomes empty after trim") {
+            test("failure when whitespace only becomes empty after trim") {
                 val result = trimMin3.tryValidate("   ")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.min"
@@ -896,31 +896,31 @@ class StringValidatorTest :
         context("toUpperCase") {
             val toUpperCase = Kova.string().toUppercase()
 
-            test("success - lowercase to uppercase") {
+            test("success when converting lowercase to uppercase") {
                 val result = toUpperCase.tryValidate("hello")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "HELLO"
             }
 
-            test("success - mixed case to uppercase") {
+            test("success when converting mixed case to uppercase") {
                 val result = toUpperCase.tryValidate("HeLLo")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "HELLO"
             }
 
-            test("success - already uppercase") {
+            test("success with already uppercase") {
                 val result = toUpperCase.tryValidate("HELLO")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "HELLO"
             }
 
-            test("success - empty string") {
+            test("success with empty string") {
                 val result = toUpperCase.tryValidate("")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe ""
             }
 
-            test("success - with numbers and symbols") {
+            test("success with numbers and symbols") {
                 val result = toUpperCase.tryValidate("hello123!@#")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "HELLO123!@#"
@@ -930,19 +930,19 @@ class StringValidatorTest :
         context("toUpperCase with constraints") {
             val toUpperCaseMin3 = Kova.string().toUppercase().min(3)
 
-            test("success - transformed value meets constraint") {
+            test("success when transformed value meets constraint") {
                 val result = toUpperCaseMin3.tryValidate("hello")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "HELLO"
             }
 
-            test("failure - transformed value violates constraint") {
+            test("failure when transformed value violates constraint") {
                 val result = toUpperCaseMin3.tryValidate("hi")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.min"
             }
 
-            test("success - combining toUpperCase with startsWith") {
+            test("success when combining toUpperCase with startsWith") {
                 val toUpperCaseStartsWithH = Kova.string().toUppercase().startsWith("H")
                 val result = toUpperCaseStartsWithH.tryValidate("hello")
                 result.isSuccess().mustBeTrue()
@@ -953,31 +953,31 @@ class StringValidatorTest :
         context("toLowerCase") {
             val toLowerCase = Kova.string().toLowercase()
 
-            test("success - uppercase to lowercase") {
+            test("success when converting uppercase to lowercase") {
                 val result = toLowerCase.tryValidate("HELLO")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("success - mixed case to lowercase") {
+            test("success when converting mixed case to lowercase") {
                 val result = toLowerCase.tryValidate("HeLLo")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("success - already lowercase") {
+            test("success with already lowercase") {
                 val result = toLowerCase.tryValidate("hello")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("success - empty string") {
+            test("success with empty string") {
                 val result = toLowerCase.tryValidate("")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe ""
             }
 
-            test("success - with numbers and symbols") {
+            test("success with numbers and symbols") {
                 val result = toLowerCase.tryValidate("HELLO123!@#")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello123!@#"
@@ -987,19 +987,19 @@ class StringValidatorTest :
         context("toLowerCase with constraints") {
             val toLowerCaseMin3 = Kova.string().toLowercase().min(3)
 
-            test("success - transformed value meets constraint") {
+            test("success when transformed value meets constraint") {
                 val result = toLowerCaseMin3.tryValidate("HELLO")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "hello"
             }
 
-            test("failure - transformed value violates constraint") {
+            test("failure when transformed value violates constraint") {
                 val result = toLowerCaseMin3.tryValidate("HI")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.min"
             }
 
-            test("success - combining toLowerCase with startsWith") {
+            test("success when combining toLowerCase with startsWith") {
                 val toLowerCaseStartsWithH = Kova.string().toLowercase().startsWith("h")
                 val result = toLowerCaseStartsWithH.tryValidate("HELLO")
                 result.isSuccess().mustBeTrue()
@@ -1010,27 +1010,27 @@ class StringValidatorTest :
         context("isEnum with Type") {
             val isEnum = Kova.string().isEnum<Status>()
 
-            test("success - ACTIVE") {
+            test("success with ACTIVE") {
                 val result = isEnum.tryValidate("ACTIVE")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "ACTIVE"
             }
-            test("success - INACTIVE") {
+            test("success with INACTIVE") {
                 val result = isEnum.tryValidate("INACTIVE")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "INACTIVE"
             }
-            test("success - PENDING") {
+            test("success with PENDING") {
                 val result = isEnum.tryValidate("PENDING")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "PENDING"
             }
-            test("failure - invalid value") {
+            test("failure with invalid value") {
                 val result = isEnum.tryValidate("INVALID")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.isEnum"
             }
-            test("failure - lowercase") {
+            test("failure with lowercase") {
                 val result = isEnum.tryValidate("active")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.isEnum"
@@ -1040,27 +1040,27 @@ class StringValidatorTest :
         context("isEnum with KClass") {
             val isEnum = Kova.string().isEnum(Status::class)
 
-            test("success - ACTIVE") {
+            test("success with ACTIVE") {
                 val result = isEnum.tryValidate("ACTIVE")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "ACTIVE"
             }
-            test("success - INACTIVE") {
+            test("success with INACTIVE") {
                 val result = isEnum.tryValidate("INACTIVE")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "INACTIVE"
             }
-            test("success - PENDING") {
+            test("success with PENDING") {
                 val result = isEnum.tryValidate("PENDING")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "PENDING"
             }
-            test("failure - invalid value") {
+            test("failure with invalid value") {
                 val result = isEnum.tryValidate("INVALID")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.isEnum"
             }
-            test("failure - lowercase") {
+            test("failure with lowercase") {
                 val result = isEnum.tryValidate("active")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.isEnum"
@@ -1070,27 +1070,27 @@ class StringValidatorTest :
         context("toEnum") {
             val toEnum = Kova.string().toEnum<Status>()
 
-            test("success - ACTIVE") {
+            test("success with ACTIVE") {
                 val result = toEnum.tryValidate("ACTIVE")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe Status.ACTIVE
             }
-            test("success - INACTIVE") {
+            test("success with INACTIVE") {
                 val result = toEnum.tryValidate("INACTIVE")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe Status.INACTIVE
             }
-            test("success - PENDING") {
+            test("success with PENDING") {
                 val result = toEnum.tryValidate("PENDING")
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe Status.PENDING
             }
-            test("failure - invalid value") {
+            test("failure with invalid value") {
                 val result = toEnum.tryValidate("INVALID")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.isEnum"
             }
-            test("failure - lowercase") {
+            test("failure with lowercase") {
                 val result = toEnum.tryValidate("active")
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.isEnum"

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/TemporalValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/TemporalValidatorTest.kt
@@ -32,12 +32,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - present") {
+                test("failure with present value") {
                     val result = validator.tryValidate(date)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(date.minusDays(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -46,17 +46,17 @@ class TemporalValidatorTest :
             context("futureOrPresent") {
                 val validator = kova.localDate().futureOrPresent()
 
-                test("success - future") {
+                test("success with future value") {
                     val result = validator.tryValidate(date.plusDays(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - present") {
+                test("success with present value") {
                     val result = validator.tryValidate(date)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(date.minusDays(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -70,12 +70,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - present") {
+                test("failure with present value") {
                     val result = validator.tryValidate(date)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(date.plusDays(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -84,17 +84,17 @@ class TemporalValidatorTest :
             context("pastOrPresent") {
                 val validator = kova.localDate().pastOrPresent()
 
-                test("success - past") {
+                test("success with past value") {
                     val result = validator.tryValidate(date.minusDays(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - present") {
+                test("success with present value") {
                     val result = validator.tryValidate(date)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(date.plusDays(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -104,12 +104,12 @@ class TemporalValidatorTest :
                 val minDate = LocalDate.of(2025, 1, 1)
                 val validator = Kova.localDate().min(minDate)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minDate)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(minDate.plusDays(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -124,12 +124,12 @@ class TemporalValidatorTest :
                 val maxDate = LocalDate.of(2025, 12, 31)
                 val validator = Kova.localDate().max(maxDate)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxDate)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(maxDate.minusDays(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -149,12 +149,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(date)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - less") {
+                test("failure with smaller value") {
                     val result = validator.tryValidate(date.minusDays(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -164,12 +164,12 @@ class TemporalValidatorTest :
                 val date = LocalDate.of(2025, 6, 15)
                 val validator = Kova.localDate().gte(date)
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(date.plusDays(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(date)
                     result.isSuccess().mustBeTrue()
                 }
@@ -189,12 +189,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(date)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - greater") {
+                test("failure with greater value") {
                     val result = validator.tryValidate(date.plusDays(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -204,12 +204,12 @@ class TemporalValidatorTest :
                 val date = LocalDate.of(2025, 6, 15)
                 val validator = Kova.localDate().lte(date)
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(date.minusDays(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(date)
                     result.isSuccess().mustBeTrue()
                 }
@@ -237,12 +237,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - present") {
+                test("failure with present value") {
                     val result = validator.tryValidate(time)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(time.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -251,17 +251,17 @@ class TemporalValidatorTest :
             context("futureOrPresent") {
                 val validator = kova.localTime().futureOrPresent()
 
-                test("success - future") {
+                test("success with future value") {
                     val result = validator.tryValidate(time.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - present") {
+                test("success with present value") {
                     val result = validator.tryValidate(time)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(time.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -275,12 +275,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - present") {
+                test("failure with present value") {
                     val result = validator.tryValidate(time)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(time.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -289,17 +289,17 @@ class TemporalValidatorTest :
             context("pastOrPresent") {
                 val validator = kova.localTime().pastOrPresent()
 
-                test("success - past") {
+                test("success with past value") {
                     val result = validator.tryValidate(time.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - present") {
+                test("success with present value") {
                     val result = validator.tryValidate(time)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(time.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -309,12 +309,12 @@ class TemporalValidatorTest :
                 val minTime = LocalTime.of(9, 0, 0)
                 val validator = Kova.localTime().min(minTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(minTime.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -329,12 +329,12 @@ class TemporalValidatorTest :
                 val maxTime = LocalTime.of(17, 0, 0)
                 val validator = Kova.localTime().max(maxTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(maxTime.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -354,12 +354,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(time)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - less") {
+                test("failure with smaller value") {
                     val result = validator.tryValidate(time.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -369,12 +369,12 @@ class TemporalValidatorTest :
                 val time = LocalTime.of(12, 0, 0)
                 val validator = Kova.localTime().gte(time)
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(time.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(time)
                     result.isSuccess().mustBeTrue()
                 }
@@ -394,12 +394,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(time)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - greater") {
+                test("failure with greater value") {
                     val result = validator.tryValidate(time.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -409,12 +409,12 @@ class TemporalValidatorTest :
                 val time = LocalTime.of(12, 0, 0)
                 val validator = Kova.localTime().lte(time)
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(time.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(time)
                     result.isSuccess().mustBeTrue()
                 }
@@ -441,12 +441,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - present") {
+                test("failure with present value") {
                     val result = validator.tryValidate(dateTime)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(dateTime.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -455,17 +455,17 @@ class TemporalValidatorTest :
             context("futureOrPresent") {
                 val validator = kova.localDateTime().futureOrPresent()
 
-                test("success - future") {
+                test("success with future value") {
                     val result = validator.tryValidate(dateTime.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - present") {
+                test("success with present value") {
                     val result = validator.tryValidate(dateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(dateTime.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -479,12 +479,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - present") {
+                test("failure with present value") {
                     val result = validator.tryValidate(dateTime)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(dateTime.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -493,17 +493,17 @@ class TemporalValidatorTest :
             context("pastOrPresent") {
                 val validator = kova.localDateTime().pastOrPresent()
 
-                test("success - past") {
+                test("success with past value") {
                     val result = validator.tryValidate(dateTime.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - present") {
+                test("success with present value") {
                     val result = validator.tryValidate(dateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(dateTime.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -513,12 +513,12 @@ class TemporalValidatorTest :
                 val minDateTime = LocalDateTime.of(2025, 1, 1, 12, 0, 0)
                 val validator = Kova.localDateTime().min(minDateTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minDateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(minDateTime.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -533,12 +533,12 @@ class TemporalValidatorTest :
                 val maxDateTime = LocalDateTime.of(2025, 12, 31, 23, 59, 59)
                 val validator = Kova.localDateTime().max(maxDateTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxDateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(maxDateTime.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -558,12 +558,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(dateTime)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - less") {
+                test("failure with smaller value") {
                     val result = validator.tryValidate(dateTime.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -573,12 +573,12 @@ class TemporalValidatorTest :
                 val dateTime = LocalDateTime.of(2025, 6, 15, 12, 0, 0)
                 val validator = Kova.localDateTime().gte(dateTime)
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(dateTime.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(dateTime)
                     result.isSuccess().mustBeTrue()
                 }
@@ -598,12 +598,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(dateTime)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - greater") {
+                test("failure with greater value") {
                     val result = validator.tryValidate(dateTime.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -613,12 +613,12 @@ class TemporalValidatorTest :
                 val dateTime = LocalDateTime.of(2025, 6, 15, 12, 0, 0)
                 val validator = Kova.localDateTime().lte(dateTime)
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(dateTime.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(dateTime)
                     result.isSuccess().mustBeTrue()
                 }
@@ -643,7 +643,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(instant.minusSeconds(3600))
                     result.isFailure().mustBeTrue()
                 }
@@ -657,7 +657,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(instant.plusSeconds(3600))
                     result.isFailure().mustBeTrue()
                 }
@@ -667,12 +667,12 @@ class TemporalValidatorTest :
                 val minInstant = Instant.parse("2025-01-01T00:00:00Z")
                 val validator = Kova.instant().min(minInstant)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minInstant)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(minInstant.plusSeconds(3600))
                     result.isSuccess().mustBeTrue()
                 }
@@ -687,12 +687,12 @@ class TemporalValidatorTest :
                 val maxInstant = Instant.parse("2025-12-31T23:59:59Z")
                 val validator = Kova.instant().max(maxInstant)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxInstant)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(maxInstant.minusSeconds(3600))
                     result.isSuccess().mustBeTrue()
                 }
@@ -709,12 +709,12 @@ class TemporalValidatorTest :
                 val minMonthDay = MonthDay.of(3, 1)
                 val validator = Kova.monthDay().min(minMonthDay)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minMonthDay)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(MonthDay.of(3, 2))
                     result.isSuccess().mustBeTrue()
                 }
@@ -729,12 +729,12 @@ class TemporalValidatorTest :
                 val maxMonthDay = MonthDay.of(10, 31)
                 val validator = Kova.monthDay().max(maxMonthDay)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxMonthDay)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(MonthDay.of(10, 30))
                     result.isSuccess().mustBeTrue()
                 }
@@ -754,12 +754,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(monthDay)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - less") {
+                test("failure with smaller value") {
                     val result = validator.tryValidate(MonthDay.of(6, 14))
                     result.isFailure().mustBeTrue()
                 }
@@ -769,12 +769,12 @@ class TemporalValidatorTest :
                 val monthDay = MonthDay.of(6, 15)
                 val validator = Kova.monthDay().gte(monthDay)
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(MonthDay.of(6, 16))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(monthDay)
                     result.isSuccess().mustBeTrue()
                 }
@@ -794,12 +794,12 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - equal") {
+                test("failure with equal value") {
                     val result = validator.tryValidate(monthDay)
                     result.isFailure().mustBeTrue()
                 }
 
-                test("failure - greater") {
+                test("failure with greater value") {
                     val result = validator.tryValidate(MonthDay.of(6, 16))
                     result.isFailure().mustBeTrue()
                 }
@@ -809,12 +809,12 @@ class TemporalValidatorTest :
                 val monthDay = MonthDay.of(6, 15)
                 val validator = Kova.monthDay().lte(monthDay)
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(MonthDay.of(6, 14))
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(monthDay)
                     result.isSuccess().mustBeTrue()
                 }
@@ -839,7 +839,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(offsetDateTime.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -853,7 +853,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(offsetDateTime.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -863,12 +863,12 @@ class TemporalValidatorTest :
                 val minOffsetDateTime = OffsetDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
                 val validator = Kova.offsetDateTime().min(minOffsetDateTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minOffsetDateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(minOffsetDateTime.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -883,12 +883,12 @@ class TemporalValidatorTest :
                 val maxOffsetDateTime = OffsetDateTime.of(2025, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC)
                 val validator = Kova.offsetDateTime().max(maxOffsetDateTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxOffsetDateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(maxOffsetDateTime.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -915,7 +915,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(offsetTime.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -929,7 +929,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(offsetTime.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -939,12 +939,12 @@ class TemporalValidatorTest :
                 val minOffsetTime = OffsetTime.of(9, 0, 0, 0, ZoneOffset.UTC)
                 val validator = Kova.offsetTime().min(minOffsetTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minOffsetTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(minOffsetTime.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -959,12 +959,12 @@ class TemporalValidatorTest :
                 val maxOffsetTime = OffsetTime.of(17, 0, 0, 0, ZoneOffset.UTC)
                 val validator = Kova.offsetTime().max(maxOffsetTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxOffsetTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(maxOffsetTime.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -991,7 +991,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(Year.of(2024))
                     result.isFailure().mustBeTrue()
                 }
@@ -1005,7 +1005,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(Year.of(2026))
                     result.isFailure().mustBeTrue()
                 }
@@ -1015,12 +1015,12 @@ class TemporalValidatorTest :
                 val minYear = Year.of(2020)
                 val validator = Kova.year().min(minYear)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minYear)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(Year.of(2021))
                     result.isSuccess().mustBeTrue()
                 }
@@ -1035,12 +1035,12 @@ class TemporalValidatorTest :
                 val maxYear = Year.of(2030)
                 val validator = Kova.year().max(maxYear)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxYear)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(Year.of(2029))
                     result.isSuccess().mustBeTrue()
                 }
@@ -1067,7 +1067,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(YearMonth.of(2024, 12))
                     result.isFailure().mustBeTrue()
                 }
@@ -1081,7 +1081,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(YearMonth.of(2025, 2))
                     result.isFailure().mustBeTrue()
                 }
@@ -1091,12 +1091,12 @@ class TemporalValidatorTest :
                 val minYearMonth = YearMonth.of(2024, 1)
                 val validator = Kova.yearMonth().min(minYearMonth)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minYearMonth)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(YearMonth.of(2024, 2))
                     result.isSuccess().mustBeTrue()
                 }
@@ -1111,12 +1111,12 @@ class TemporalValidatorTest :
                 val maxYearMonth = YearMonth.of(2025, 12)
                 val validator = Kova.yearMonth().max(maxYearMonth)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxYearMonth)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(YearMonth.of(2025, 11))
                     result.isSuccess().mustBeTrue()
                 }
@@ -1141,7 +1141,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - past") {
+                test("failure with past value") {
                     val result = validator.tryValidate(zonedDateTime.minusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -1155,7 +1155,7 @@ class TemporalValidatorTest :
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("failure - future") {
+                test("failure with future value") {
                     val result = validator.tryValidate(zonedDateTime.plusHours(1))
                     result.isFailure().mustBeTrue()
                 }
@@ -1165,12 +1165,12 @@ class TemporalValidatorTest :
                 val minZonedDateTime = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
                 val validator = Kova.zonedDateTime().min(minZonedDateTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(minZonedDateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - greater") {
+                test("success with greater value") {
                     val result = validator.tryValidate(minZonedDateTime.plusHours(1))
                     result.isSuccess().mustBeTrue()
                 }
@@ -1185,12 +1185,12 @@ class TemporalValidatorTest :
                 val maxZonedDateTime = ZonedDateTime.of(2025, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC)
                 val validator = Kova.zonedDateTime().max(maxZonedDateTime)
 
-                test("success - equal") {
+                test("success with equal value") {
                     val result = validator.tryValidate(maxZonedDateTime)
                     result.isSuccess().mustBeTrue()
                 }
 
-                test("success - less") {
+                test("success with smaller value") {
                     val result = validator.tryValidate(maxZonedDateTime.minusHours(1))
                     result.isSuccess().mustBeTrue()
                 }

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
@@ -54,7 +54,7 @@ class ValidatorTest :
             }
         }
 
-        context("and - lambda") {
+        context("and with lambda") {
             val and = Kova.int().min(2).and { it.max(3) }
 
             test("success") {
@@ -72,15 +72,15 @@ class ValidatorTest :
             val length5 = Kova.string().length(5)
             val length2or5 = length2 or length5
 
-            test("success - length(2)") {
+            test("success with length 2") {
                 val result = length2or5.tryValidate("ab")
                 result.isSuccess().mustBeTrue()
             }
-            test("success - length(5)") {
+            test("success with length 5") {
                 val result = length2or5.tryValidate("abcde")
                 result.isSuccess().mustBeTrue()
             }
-            test("failure - length(3)") {
+            test("failure with length 3") {
                 val result = length2or5.tryValidate("abc")
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -99,7 +99,7 @@ class ValidatorTest :
             val length7 = Kova.string().length(7)
             val length2or5or7 = length2 or length5 or length7
 
-            test("failure - length(3)") {
+            test("failure with length 3") {
                 val result = length2or5or7.tryValidate("abc")
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -121,7 +121,7 @@ class ValidatorTest :
                     .or { it.length(5) }
                     .or { it.length(7) }
 
-            test("failure - length(3)") {
+            test("failure with length 3") {
                 val result = length2or5or7.tryValidate("abc")
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -157,12 +157,12 @@ class ValidatorTest :
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "3"
             }
-            test("failure - first constraint violated") {
+            test("failure when first constraint violated") {
                 val result = validator.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.comparable.min"
             }
-            test("failure - second constraint violated") {
+            test("failure when second constraint violated") {
                 val result = validator.tryValidate(10)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.max"
@@ -176,12 +176,12 @@ class ValidatorTest :
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "3"
             }
-            test("failure - first constraint violated") {
+            test("failure when first constraint violated") {
                 val result = validator.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.comparable.min"
             }
-            test("failure - second constraint violated") {
+            test("failure when second constraint violated") {
                 val result = validator.tryValidate(10)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.max"
@@ -200,12 +200,12 @@ class ValidatorTest :
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "3"
             }
-            test("failure - first constraint violated") {
+            test("failure when first constraint violated") {
                 val result = validator.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.comparable.min"
             }
-            test("failure - second constraint violated") {
+            test("failure when second constraint violated") {
                 val result = validator.tryValidate(10)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.max"
@@ -224,12 +224,12 @@ class ValidatorTest :
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe "3"
             }
-            test("failure - first constraint violated") {
+            test("failure when first constraint violated") {
                 val result = validator.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.comparable.min"
             }
-            test("failure - second constraint violated") {
+            test("failure when second constraint violated") {
                 val result = validator.tryValidate(10)
                 result.isFailure().mustBeTrue()
                 result.messages.single().constraintId shouldBe "kova.string.max"

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/WithDefaultNullableValidatorTest.kt
@@ -9,29 +9,29 @@ class WithDefaultNullableValidatorTest :
         context("nullable") {
             val nullable = Kova.nullable(0)
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullable.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0
             }
 
-            test("success - non null") {
+            test("success with non-null value") {
                 val result = nullable.tryValidate(123)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 123
             }
         }
 
-        context("nullable - default value with lambda") {
+        context("nullable with default value from lambda") {
             val nullable = Kova.nullable { 0 }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullable.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0
             }
 
-            test("success - non null") {
+            test("success with non-null value") {
                 val result = nullable.tryValidate(123)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 123
@@ -42,13 +42,13 @@ class WithDefaultNullableValidatorTest :
             val min3 = Kova.int().min(3)
             val whenNotNullMin3 = Kova.nullable(3).and(min3)
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val result = whenNotNullMin3.tryValidate(4)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 4
             }
 
-            test("success - null") {
+            test("success with null value") {
                 val logs = mutableListOf<LogEntry>()
                 val result = whenNotNullMin3.tryValidate(null, config = ValidationConfig(logger = { logs.add(it) }))
                 result.isSuccess().mustBeTrue(result)
@@ -56,7 +56,7 @@ class WithDefaultNullableValidatorTest :
                 logs shouldBe listOf()
             }
 
-            test("failure - min 3constraint violated") {
+            test("failure when min 3 constraint violated") {
                 val result = whenNotNullMin3.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -64,22 +64,22 @@ class WithDefaultNullableValidatorTest :
             }
         }
 
-        context("and - each List element") {
+        context("and with each List element") {
             val min3 = Kova.int().min(3)
             val nullableMin3 = Kova.nullable(0).and(min3)
             val onEachNullableMin3 = Kova.list<Int?>().onEach(nullableMin3)
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val result = onEachNullableMin3.tryValidate(listOf(4, 5))
                 result.isSuccess().mustBeTrue()
             }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = onEachNullableMin3.tryValidate(listOf(null, null))
                 result.isSuccess().mustBeTrue()
             }
 
-            test("failure - min3　constraint violated") {
+            test("failure when min3 constraint violated") {
                 val result = onEachNullableMin3.tryValidate(listOf(2, null))
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -91,20 +91,20 @@ class WithDefaultNullableValidatorTest :
             val min3 = Kova.int().min(3)
             val nullableMin3 = min3.asNullable(0)
 
-            test("success - non-null") {
+            test("success with non-null value") {
                 val result = nullableMin3.tryValidate(4)
                 result.isSuccess().mustBeTrue()
                 val value: Int = result.value // The type is "Int" instead of "Int?"
                 value shouldBe 4
             }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullableMin3.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 0
             }
 
-            test("failure - min3 constraint is violated") {
+            test("failure when min3 constraint is violated") {
                 val result = nullableMin3.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
@@ -122,20 +122,20 @@ class WithDefaultNullableValidatorTest :
                 result.isSuccess().mustBeTrue()
             }
 
-            test("success - null") {
+            test("success with null value") {
                 val result = nullableThenMin3AndMax3.tryValidate(null)
                 result.isSuccess().mustBeTrue()
                 result.value shouldBe 4
             }
 
-            test("failure - min3 constraint is violated") {
+            test("failure when min3 constraint is violated") {
                 val result = nullableThenMin3AndMax3.tryValidate(2)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1
                 result.messages[0].constraintId shouldBe "kova.comparable.min"
             }
 
-            test("failure - max5 constraint violated") {
+            test("failure when max5 constraint violated") {
                 val result = nullableThenMin3AndMax3.tryValidate(6)
                 result.isFailure().mustBeTrue()
                 result.messages.size shouldBe 1


### PR DESCRIPTION
## Summary
Standardize test descriptions across all validator test files to improve maintainability and consistency.

## Changes
- Replace inconsistent dash separator patterns (`-`) with natural English ("with", "when", "for")
- Standardize test naming: `test("success with [condition]")` and `test("failure when [condition]")`
- Standardize context naming: `context("feature with variation")` instead of `context("feature - variation")`
- Fix unicode whitespace characters (U+3000) in test names

## Examples
**Before:**
```kotlin
test("success - equal") { ... }
test("failure - null") { ... }
test("success : 2") { ... }
context("and - lambda") { ... }
```

**After:**
```kotlin
test("success with equal value") { ... }
test("failure with null value") { ... }
test("success with value 2") { ... }
context("and with lambda") { ... }
```

## Files Modified
- 12 test files
- 305 insertions, 305 deletions (consistent replacements)

## Test Results
✅ All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)