### PR TITLE
Add documentation and tests for choose method overloads

### DIFF
--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectSchemaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectSchemaTest.kt
@@ -473,4 +473,22 @@ class ObjectSchemaTest :
                 result.messages[0].constraintId shouldBeEqual "kova.comparable.max"
             }
         }
+
+        context("temporal property") {
+            data class User(
+                val name: String,
+                val birthday: java.time.LocalDate,
+            )
+            val userSchema =
+                object : ObjectSchema<User>() {
+                    val name = User::name { it.notBlank() }
+                    val birthday = User::birthday { Kova.localDate() }
+                }
+
+            test("success") {
+                val user = User("abc", java.time.LocalDate.of(2021, 1, 1))
+                val result = userSchema.tryValidate(user)
+                result.isSuccess().mustBeTrue()
+            }
+        }
     })


### PR DESCRIPTION
## Summary

- Add comprehensive KDoc comments for both `choose` method overloads in ObjectSchema
- Rename parameter from `block` to `resolve` for consistency across overloads  
- Add new `choose(select, resolve)` overload that allows selecting a specific value from the object before determining which validator to apply
- Add test demonstrating dynamic validator selection based on object properties (e.g., postal code validation based on country)
- Reorganize helper functions in ObjectFactory for better code organization

## Test plan

- [x] All existing tests pass
- [x] Added new test in `ObjectFactoryTest` demonstrating dynamic validator with `choose(select, resolve)` method
- [x] Added new test in `ObjectSchemaTest` for temporal property validation
- [x] Code formatted with spotlessApply

🤖 Generated with [Claude Code](https://claude.com/claude-code)