### PR TITLE
refactor: simplify isNullOr and notNullAnd API for better DSL ergonomics

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
@@ -77,13 +77,10 @@ fun <T : Any, S : Any> NullableValidator<T, S>.isNull(message: MessageProvider =
  * ```
  *
  * @param block A function that builds a validator from a success validator
- * @param message Custom error message provider for the null check
  * @return A new validator that accepts null or values satisfying the block validator
  */
-fun <T : Any, S : Any> NullableValidator<T, S>.isNullOr(
-    block: (Validator<T, T>) -> Validator<T, S>,
-    message: MessageProvider = MessageProvider.resource(),
-): NullableValidator<T, S> = isNull(message).or(block(Validator.success()).asNullable())
+fun <T : Any, S : Any> NullableValidator<T, S>.isNullOr(block: (Validator<T, T>) -> Validator<T, S>): NullableValidator<T, S> =
+    isNull().or(block(Validator.success()).asNullable())
 
 /**
  * Validates that the input is not null.
@@ -122,13 +119,10 @@ fun <T : Any, S : Any> NullableValidator<T, S>.notNull(message: MessageProvider 
  * ```
  *
  * @param block A function that builds a validator from a success validator
- * @param message Custom error message provider for the null check
  * @return A new validator that rejects null and validates non-null values with the block validator
  */
-fun <T : Any, S : Any> NullableValidator<T, S>.notNullAnd(
-    block: (Validator<T, T>) -> Validator<T, S>,
-    message: MessageProvider = MessageProvider.resource(),
-): NullableValidator<T, S> = notNull(message).and(block(Validator.success()).asNullable())
+fun <T : Any, S : Any> NullableValidator<T, S>.notNullAnd(block: (Validator<T, T>) -> Validator<T, S>): NullableValidator<T, S> =
+    notNull().and(block(Validator.success()).asNullable())
 
 /**
  * Converts a nullable validator to a validator with non-nullable output.

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaTest.kt
@@ -62,7 +62,7 @@ class KovaTest :
 
             val nullable = Kova.nullable<String>()
             val notNull = nullable.notNull()
-            val notNullAndMin3 = nullable.notNullAnd({ it.min(3) }).toNonNullable()
+            val notNullAndMin3 = nullable.notNullAnd { it.min(3) }.toNonNullable()
             val requestKey = Kova.generic<Request>().name("Request[key]").map { it["key"] }
             val requestKeyIsNotNull = requestKey.then(notNull)
             val requestKeyIsNotNullAndMin3 = requestKey.then(notNullAndMin3)

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
@@ -103,7 +103,7 @@ class NullableValidatorTest :
         }
 
         context("isNullOr") {
-            val isNullOrMin3Max3 = Kova.nullable<Int>().isNullOr({ it.min(3).max(3) })
+            val isNullOrMin3Max3 = Kova.nullable<Int>().isNullOr { it.min(3).max(3) }
 
             test("success with null value") {
                 val result = isNullOrMin3Max3.tryValidate(null)
@@ -141,7 +141,7 @@ class NullableValidatorTest :
         }
 
         context("notNullAnd") {
-            val notNullAndMin3 = Kova.nullable<Int>().notNullAnd({ it.min(3) })
+            val notNullAndMin3 = Kova.nullable<Int>().notNullAnd { it.min(3) }
 
             test("success") {
                 val result = notNullAndMin3.tryValidate(4)
@@ -266,7 +266,7 @@ class NullableValidatorTest :
         }
 
         context("logs") {
-            val isNullOrMin3Max3 = Kova.nullable<Int>().isNullOr({ it.min(3) })
+            val isNullOrMin3Max3 = Kova.nullable<Int>().isNullOr { it.min(3) }
 
             test("success: 3") {
                 val logs = mutableListOf<LogEntry>()


### PR DESCRIPTION
## Summary
- Removed `message` parameter from `isNullOr` and `notNullAnd` methods
- Simplified DSL usage by allowing cleaner lambda syntax without parentheses
- Updated all tests to use the improved syntax

## Motivation
The message parameter was rarely customized in these methods, and removing it significantly improves the DSL ergonomics. Users can now write:

```kotlin
// Before
nullable.isNullOr({ it.min(3) })
nullable.notNullAnd({ it.min(3) })

// After
nullable.isNullOr { it.min(3) }
nullable.notNullAnd { it.min(3) }
```

## Changes
- `NullableValidator.kt`: Removed `message` parameter from `isNullOr` and `notNullAnd` method signatures
- Updated KDoc to reflect the simplified API
- Updated all test files to use the cleaner syntax

## Test Plan
- [x] All existing tests pass with updated syntax
- [x] API behavior remains unchanged
- [x] DSL is more concise and readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)