### PR TITLE
Stop returning ValidationContext in ValidationResult.Success

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ConstraintValidator.kt
@@ -42,7 +42,7 @@ fun <T> ConstraintValidator(constraint: Constraint<T>): ConstraintValidator<T> =
                         input = input,
                     )
                 }
-                ValidationResult.Success(input, context)
+                ValidationResult.Success(input)
             }
 
             is ConstraintResult.Violated -> {

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/IdentityValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/IdentityValidator.kt
@@ -65,7 +65,7 @@ fun <T> IdentityValidator<T>.chain(next: IdentityValidator<T>): IdentityValidato
     IdentityValidator { input, context ->
         when (val result = execute(input, context)) {
             is Success -> {
-                next.execute(result.value, result.context)
+                next.execute(result.value, context)
             }
 
             is Failure -> {
@@ -150,7 +150,7 @@ fun <T> IdentityValidator<T>.onlyIf(condition: (T) -> Boolean) =
         if (condition(input)) {
             execute(input, context)
         } else {
-            Success(input, context)
+            Success(input)
         }
     }
 
@@ -183,5 +183,5 @@ fun <T> IdentityValidator<T>.onlyIf(condition: (T) -> Boolean) =
  */
 fun <T : Any> IdentityValidator<T>.asNullable(): NullableValidator<T, T> =
     Validator { input, context ->
-        if (input == null) Success(null, context) else execute(input, context)
+        if (input == null) Success(null) else execute(input, context)
     }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectSchema.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectSchema.kt
@@ -82,7 +82,7 @@ open class ObjectSchema<T : Any>(
             }
             results.add(result)
         }
-        return results.fold(ValidationResult.Success(input, context), ValidationResult<T>::plus)
+        return results.fold(ValidationResult.Success(input), ValidationResult<T>::plus)
     }
 
     private fun applyRule(
@@ -96,13 +96,13 @@ open class ObjectSchema<T : Any>(
         val pathResult = context.addPathChecked(key.name, value)
         return when (pathResult) {
             is ValidationResult.Success -> {
-                when (val result = validator.execute(pathResult.value, pathResult.context)) {
-                    is ValidationResult.Success -> ValidationResult.Success(input, result.context)
+                when (val result = validator.execute(value, pathResult.value)) {
+                    is ValidationResult.Success -> ValidationResult.Success(input)
                     is ValidationResult.Failure -> ValidationResult.Failure(Input.Available(input), result.messages)
                 }
             }
             // If circular reference detected, terminate validation early with success
-            is ValidationResult.Failure -> ValidationResult.Success(input, context)
+            is ValidationResult.Failure -> ValidationResult.Success(input)
         }
     }
 

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
@@ -174,7 +174,7 @@ fun ValidationContext.bindObject(obj: Any?): ValidationContext {
 fun <T> ValidationContext.addPathChecked(
     name: String,
     obj: T,
-): ValidationResult<T> {
+): ValidationResult<ValidationContext> {
     val parent = this.path
     // Check for circular reference
     if (obj != null && parent.containsObject(obj)) {
@@ -183,9 +183,9 @@ fun <T> ValidationContext.addPathChecked(
         val constraintContext = createConstraintContext(obj, "kova.circularReference")
         val messageContext = constraintContext.createMessageContext(emptyList())
         val message = Message.Text(messageContext, "Circular reference detected.")
-        return ValidationResult.Failure(Input.Available(obj), listOf(message))
+        return ValidationResult.Failure(Input.Available(this), listOf(message))
     }
-    return ValidationResult.Success(obj, addPath(name, obj))
+    return ValidationResult.Success(addPath(name, obj))
 }
 
 /**

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationResult.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationResult.kt
@@ -29,10 +29,7 @@ sealed interface ValidationResult<out T> {
      * @param value The validated value
      * @param context The validation context after validation completed
      */
-    data class Success<T>(
-        val value: T,
-        val context: ValidationContext,
-    ) : ValidationResult<T>
+    data class Success<T>(val value: T) : ValidationResult<T>
 
     /**
      * Represents a failed validation with detailed error information.

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/Validator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/Validator.kt
@@ -43,7 +43,7 @@ fun interface Validator<IN, OUT> {
          *
          * @return An identity validator that always succeeds
          */
-        fun <T> success() = IdentityValidator<T> { input, context -> Success(input, context) }
+        fun <T> success() = IdentityValidator<T> { input, context -> Success(input) }
     }
 }
 
@@ -243,7 +243,7 @@ inline fun <IN, reified OUT, reified NEW> Validator<IN, OUT>.map(noinline transf
     val newClass = NEW::class
     return Validator { input, context ->
         when (val result = self.execute(input, context)) {
-            is Success -> Success(transform(result.value), result.context)
+            is Success -> Success(transform(result.value))
             is Failure -> {
                 val failureValue =
                     when (val v = result.value) {
@@ -282,7 +282,7 @@ fun <IN, OUT> Validator<IN, OUT>.name(name: String): Validator<IN, OUT> {
     return Validator { input, context ->
         val context = context.addPath(name, input)
         when (val result = self.execute(input, context)) {
-            is Success -> Success(result.value, result.context)
+            is Success -> Success(result.value)
             is Failure -> result
         }
     }
@@ -342,7 +342,7 @@ fun <IN, OUT, NEW> Validator<IN, OUT>.then(after: Validator<OUT, NEW>): Validato
     val before = this
     return Validator { input, context ->
         when (val result = before.execute(input, context)) {
-            is Success -> after.execute(result.value, result.context)
+            is Success -> after.execute(result.value, context)
             is Failure -> {
                 val value =
                     when (val v = result.value) {
@@ -396,7 +396,7 @@ fun <IN, OUT, NEW> Validator<IN, OUT>.then(block: (Validator<OUT, OUT>) -> Valid
  */
 fun <T : Any, S : Any> Validator<T, S>.asNullable(): NullableValidator<T, S> =
     Validator { input, context ->
-        if (input == null) Success(null, context) else execute(input, context)
+        if (input == null) Success(null) else execute(input, context)
     }
 
 /**
@@ -436,7 +436,7 @@ fun <T : Any, S : Any> Validator<T, S>.asNullable(defaultValue: S): NullCoalesci
  */
 fun <T : Any, S : Any> Validator<T, S>.asNullable(withDefault: () -> S): NullCoalescingValidator<T, S> =
     Validator { input, context ->
-        if (input == null) Success(withDefault(), context) else execute(input, context)
+        if (input == null) Success(withDefault()) else execute(input, context)
     }
 
 /**

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaTest.kt
@@ -63,9 +63,9 @@ class KovaTest :
             val nullable = Kova.nullable<String>()
             val notNull = nullable.notNull()
             val notNullAndMin3 = nullable.notNullAnd { it.min(3) }.toNonNullable()
-            val requestKey = Kova.generic<Request>().name("Request[key]").map { it["key"] }
-            val requestKeyIsNotNull = requestKey.then(notNull)
-            val requestKeyIsNotNullAndMin3 = requestKey.then(notNullAndMin3)
+            val requestKey = Kova.generic<Request>().map { it["key"] }
+            val requestKeyIsNotNull = requestKey.then(notNull).name("Request[key]")
+            val requestKeyIsNotNullAndMin3 = requestKey.then(notNullAndMin3).name("Request[key]")
 
             test("success when requestKey is not null") {
                 val result = requestKeyIsNotNull.tryValidate(Request(mapOf("key" to "abc")))


### PR DESCRIPTION
It's largely unnecessary given that logging is already mutable. It only changes the behaviour of 2 tests, both of which involve `.name`. The behaviour change makes a lot of sense IMO. It means that `name` only applies to the validator you call it on, and doesn't affect further validation steps that you add after it.