### PR TITLE
Fix circular reference issue in ObjectSchema

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectSchema.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ObjectSchema.kt
@@ -296,12 +296,9 @@ class ObjectSchemaScope<T : Any> internal constructor(
      * ```
      *
      * @param block Lambda that receives a base validator and creates the validator for this property
-     * @return The validator created by the block
      */
-    operator fun <V, VALIDATOR : Validator<V, V>> KProperty1<T, V>.invoke(block: (Validator<V, V>) -> VALIDATOR): VALIDATOR {
-        val validator = block(Validator.success())
-        addRule(this) { _ -> validator }
-        return validator
+    operator fun <V, VALIDATOR : Validator<V, V>> KProperty1<T, V>.invoke(block: (Validator<V, V>) -> VALIDATOR) {
+        addRule(this) { _ -> block(Validator.success()) }
     }
 
     /**
@@ -328,12 +325,10 @@ class ObjectSchemaScope<T : Any> internal constructor(
      * ```
      *
      * @param resolve Lambda that receives the object and a base validator, and chooses a validator
-     * @return The resolution function for further use
      */
-    infix fun <V, VALIDATOR : IdentityValidator<V>> KProperty1<T, V>.choose(resolve: (T, Validator<V, V>) -> VALIDATOR): (T) -> VALIDATOR {
+    infix fun <V, VALIDATOR : IdentityValidator<V>> KProperty1<T, V>.choose(resolve: (T, Validator<V, V>) -> VALIDATOR) {
         val chooser = { receiver: T -> resolve(receiver, Validator.success()) }
         addRule(this, chooser)
-        return chooser
     }
 
     internal fun <V> addRule(

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectSchemaCircularReferenceTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ObjectSchemaCircularReferenceTest.kt
@@ -1,0 +1,30 @@
+package org.komapper.extension.validator
+
+import io.kotest.core.spec.style.FunSpec
+
+class ObjectSchemaCircularReferenceTest :
+    FunSpec({
+
+        test("circular reference between schemas") {
+            val city = City(emptyList())
+            val user = User(city)
+            CitySchema.validate(city)
+            UserSchema.validate(user)
+        }
+    }) {
+    class City(
+        val users: List<User>,
+    )
+
+    class User(
+        val city: City,
+    )
+
+    object CitySchema : ObjectSchema<City>({
+        City::users { it.onEach(UserSchema) }
+    })
+
+    object UserSchema : ObjectSchema<User>({
+        User::city { CitySchema }
+    })
+}


### PR DESCRIPTION
## Summary
- Modified `ObjectSchemaScope.invoke()` and `ObjectSchemaScope.choose()` to remove return values, fixing circular reference issues when schemas reference each other
- Added `ObjectSchemaCircularReferenceTest` to verify schemas can properly reference each other without causing initialization problems

## Details
The issue occurred because `invoke()` and `choose()` methods were returning validator instances created during schema initialization. When schemas had circular references (e.g., City has Users, User has City), this could lead to initialization order problems.

The fix changes these methods to create validators lazily within the `addRule()` lambda, ensuring validators are instantiated only when needed during validation, not during schema initialization.

## Test plan
- ✅ Added test case with mutually referencing `City` and `User` schemas
- ✅ Verified both schemas can be validated without circular reference errors
- ✅ Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)