### PR TITLE
Add formatting check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
 
+    - name: Check formatting
+      run: ./gradlew spotlessCheck --no-daemon
+
     - name: Build project
       run: ./gradlew build --no-daemon
 


### PR DESCRIPTION
## Summary
- Adds `spotlessCheck` step to CI workflow before the build step to automatically validate code formatting in the CI pipeline

## Test plan
- [x] Verify CI workflow runs successfully with the new formatting check step
- [x] Confirm that formatting violations would be caught before build

🤖 Generated with [Claude Code](https://claude.com/claude-code)