### PR TITLE
Turn ValidationResult into an Ior monad

### DIFF
--- a/example-factory/src/main/kotlin/example/Main.kt
+++ b/example-factory/src/main/kotlin/example/Main.kt
@@ -54,7 +54,7 @@ object PersonFactory {
         age: String,
     ) = Kova.factory {
         val name by bind(name) { it.min(1).notBlank() } // argument validator
-        val age by bind(AgeFactory(age)) // argument validator
+        val age by AgeFactory(age) // argument validator
         create { Person(name(), age()) }
     }
 }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/CharSequenceValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/CharSequenceValidator.kt
@@ -4,9 +4,10 @@ package org.komapper.extension.validator
  * Represents a type alias for a validator that operates on types extending CharSequence.
  * This alias is used to simplify or clarify the designation of a validator for CharSequence-related types.
  *
- * @param T the type parameter that must extend CharSequence
+ * @param T the input type of the validator
+ * @param S the type parameter that must extend CharSequence
  */
-typealias CharSequenceValidator<T> = IdentityValidator<T>
+typealias CharSequenceValidator<T, S> = Validator<T, S>
 
 /**
  * Validates that the character sequence length is at least the specified minimum.
@@ -22,7 +23,7 @@ typealias CharSequenceValidator<T> = IdentityValidator<T>
  * @param message Custom error message provider
  * @return A new validator with the minimum length constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.min(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.min(
     length: Int,
     message: MessageProvider = { "kova.charSequence.min".resource(length) },
 ) = constrain("kova.charSequence.min") { satisfies(it.length >= length, message) }
@@ -41,7 +42,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.min(
  * @param message Custom error message provider
  * @return A new validator with the maximum length constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.max(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.max(
     length: Int,
     message: MessageProvider = { "kova.charSequence.max".resource(length) },
 ) = constrain("kova.charSequence.max") { satisfies(it.length <= length, message) }
@@ -60,7 +61,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.max(
  * @param message Custom error message provider
  * @return A new validator with the not-blank constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.notBlank(message: MessageProvider = { "kova.charSequence.notBlank".resource }) =
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.notBlank(message: MessageProvider = { "kova.charSequence.notBlank".resource }) =
     constrain("kova.charSequence.notBlank") { satisfies(it.isNotBlank(), message) }
 
 /**
@@ -77,7 +78,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.notBlank(message: MessageProvide
  * @param message Custom error message provider
  * @return A new validator with the blank constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.blank(message: MessageProvider = { "kova.charSequence.blank".resource }) =
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.blank(message: MessageProvider = { "kova.charSequence.blank".resource }) =
     constrain("kova.charSequence.blank") { satisfies(it.isBlank(), message) }
 
 /**
@@ -94,7 +95,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.blank(message: MessageProvider =
  * @param message Custom error message provider
  * @return A new validator with the not-empty constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.notEmpty(message: MessageProvider = { "kova.charSequence.notEmpty".resource }) =
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.notEmpty(message: MessageProvider = { "kova.charSequence.notEmpty".resource }) =
     constrain("kova.charSequence.notEmpty") { satisfies(it.isNotEmpty(), message) }
 
 /**
@@ -111,7 +112,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.notEmpty(message: MessageProvide
  * @param message Custom error message provider
  * @return A new validator with the empty constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.empty(message: MessageProvider = { "kova.charSequence.empty".resource }) =
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.empty(message: MessageProvider = { "kova.charSequence.empty".resource }) =
     constrain("kova.charSequence.empty") { satisfies(it.isEmpty(), message) }
 
 /**
@@ -128,7 +129,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.empty(message: MessageProvider =
  * @param message Custom error message provider
  * @return A new validator with the exact length constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.length(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.length(
     length: Int,
     message: MessageProvider = { "kova.charSequence.length".resource(length) },
 ) = constrain("kova.charSequence.length") { satisfies(it.length == length, message) }
@@ -147,7 +148,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.length(
  * @param message Custom error message provider
  * @return A new validator with the starts-with constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.startsWith(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.startsWith(
     prefix: CharSequence,
     message: MessageProvider = { "kova.charSequence.startsWith".resource(prefix) },
 ) = constrain("kova.charSequence.startsWith") { satisfies(it.startsWith(prefix), message) }
@@ -166,7 +167,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.startsWith(
  * @param message Custom error message provider
  * @return A new validator with the not-starts-with constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.notStartsWith(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.notStartsWith(
     prefix: CharSequence,
     message: MessageProvider = { "kova.charSequence.notStartsWith".resource(prefix) },
 ) = constrain("kova.charSequence.notStartsWith") { satisfies(!it.startsWith(prefix), message) }
@@ -185,7 +186,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.notStartsWith(
  * @param message Custom error message provider
  * @return A new validator with the ends-with constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.endsWith(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.endsWith(
     suffix: CharSequence,
     message: MessageProvider = { "kova.charSequence.endsWith".resource(suffix) },
 ) = constrain("kova.charSequence.endsWith") { satisfies(it.endsWith(suffix), message) }
@@ -204,7 +205,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.endsWith(
  * @param message Custom error message provider
  * @return A new validator with the not-ends-with constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.notEndsWith(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.notEndsWith(
     suffix: CharSequence,
     message: MessageProvider = { "kova.charSequence.notEndsWith".resource(suffix) },
 ) = constrain("kova.charSequence.notEndsWith") { satisfies(!it.endsWith(suffix), message) }
@@ -223,7 +224,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.notEndsWith(
  * @param message Custom error message provider
  * @return A new validator with the contains constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.contains(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.contains(
     infix: CharSequence,
     message: MessageProvider = { "kova.charSequence.contains".resource(infix) },
 ) = constrain("kova.charSequence.contains") { satisfies(it.contains(infix), message) }
@@ -242,7 +243,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.contains(
  * @param message Custom error message provider
  * @return A new validator with the not-contains constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.notContains(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.notContains(
     infix: CharSequence,
     message: MessageProvider = { "kova.charSequence.notContains".resource(infix) },
 ) = constrain("kova.charSequence.notContains") { satisfies(!it.contains(infix), message) }
@@ -261,7 +262,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.notContains(
  * @param message Custom error message provider
  * @return A new validator with the regex constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.matches(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.matches(
     pattern: Regex,
     message: MessageProvider = { "kova.charSequence.matches".resource(pattern) },
 ) = constrain("kova.charSequence.matches") { satisfies(pattern.matches(it), message) }
@@ -280,7 +281,7 @@ fun <T : CharSequence> CharSequenceValidator<T>.matches(
  * @param message Custom error message provider
  * @return A new validator with the not-matches constraint
  */
-fun <T : CharSequence> CharSequenceValidator<T>.notMatches(
+fun <T, S : CharSequence> CharSequenceValidator<T, S>.notMatches(
     pattern: Regex,
     message: MessageProvider = { "kova.charSequence.notMatches".resource(pattern) },
 ) = constrain("kova.charSequence.notMatches") { satisfies(!pattern.matches(it), message) }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ComparableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ComparableValidator.kt
@@ -16,7 +16,7 @@ package org.komapper.extension.validator
  * val dateValidator: ComparableValidator<LocalDate> = Kova.temporal<LocalDate>().min(LocalDate.now())
  * ```
  */
-typealias ComparableValidator<T> = IdentityValidator<T>
+typealias ComparableValidator<T, S> = Validator<T, S>
 
 /**
  * Validates that the number is greater than or equal to the specified minimum value.
@@ -32,10 +32,10 @@ typealias ComparableValidator<T> = IdentityValidator<T>
  * @param message Custom error message provider
  * @return A new validator with the minimum constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.min(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.min(
+    value: S,
     message: MessageProvider = { "kova.comparable.min".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.min") { satisfies(it >= value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.min") { satisfies(it >= value, message) }
 
 /**
  * Validates that the number is less than or equal to the specified maximum value.
@@ -51,10 +51,10 @@ fun <T : Comparable<T>> ComparableValidator<T>.min(
  * @param message Custom error message provider
  * @return A new validator with the maximum constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.max(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.max(
+    value: S,
     message: MessageProvider = { "kova.comparable.max".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.max") { satisfies(it <= value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.max") { satisfies(it <= value, message) }
 
 /**
  * Validates that the number is strictly greater than the specified value.
@@ -71,10 +71,10 @@ fun <T : Comparable<T>> ComparableValidator<T>.max(
  * @param message Custom error message provider
  * @return A new validator with the greater-than constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.gt(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.gt(
+    value: S,
     message: MessageProvider = { "kova.comparable.gt".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.gt") { satisfies(it > value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.gt") { satisfies(it > value, message) }
 
 /**
  * Validates that the number is greater than or equal to the specified value.
@@ -91,10 +91,10 @@ fun <T : Comparable<T>> ComparableValidator<T>.gt(
  * @param message Custom error message provider
  * @return A new validator with the greater-than-or-equal constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.gte(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.gte(
+    value: S,
     message: MessageProvider = { "kova.comparable.gte".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.gte") { satisfies(it >= value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.gte") { satisfies(it >= value, message) }
 
 /**
  * Validates that the number is strictly less than the specified value.
@@ -111,10 +111,10 @@ fun <T : Comparable<T>> ComparableValidator<T>.gte(
  * @param message Custom error message provider
  * @return A new validator with the less-than constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.lt(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.lt(
+    value: S,
     message: MessageProvider = { "kova.comparable.lt".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.lt") { satisfies(it < value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.lt") { satisfies(it < value, message) }
 
 /**
  * Validates that the number is less than or equal to the specified value.
@@ -131,10 +131,10 @@ fun <T : Comparable<T>> ComparableValidator<T>.lt(
  * @param message Custom error message provider
  * @return A new validator with the less-than-or-equal constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.lte(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.lte(
+    value: S,
     message: MessageProvider = { "kova.comparable.lte".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.lte") { satisfies(it <= value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.lte") { satisfies(it <= value, message) }
 
 /**
  * Validates that the value is equal to the specified value.
@@ -151,10 +151,10 @@ fun <T : Comparable<T>> ComparableValidator<T>.lte(
  * @param message Custom error message provider
  * @return A new validator with the equality constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.eq(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.eq(
+    value: S,
     message: MessageProvider = { "kova.comparable.eq".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.eq") { satisfies(it == value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.eq") { satisfies(it == value, message) }
 
 /**
  * Validates that the value is not equal to the specified value.
@@ -171,7 +171,7 @@ fun <T : Comparable<T>> ComparableValidator<T>.eq(
  * @param message Custom error message provider
  * @return A new validator with the inequality constraint
  */
-fun <T : Comparable<T>> ComparableValidator<T>.notEq(
-    value: T,
+fun <T, S : Comparable<S>> ComparableValidator<T, S>.notEq(
+    value: S,
     message: MessageProvider = { "kova.comparable.notEq".resource(value) },
-): ComparableValidator<T> = constrain("kova.comparable.notEq") { satisfies(it != value, message) }
+): ComparableValidator<T, S> = constrain("kova.comparable.notEq") { satisfies(it != value, message) }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/Constraint.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/Constraint.kt
@@ -25,14 +25,7 @@ package org.komapper.extension.validator
  *
  * @param T The type of value this constraint validates
  */
-typealias Constraint<T> = Validator<T, Unit>
-
-/**
- * Result of applying a constraint to a value.
- *
- * Either [ValidationResult.Success] if the constraint passes, or [ValidationResult.Failure] if it fails.
- */
-typealias ConstraintResult = ValidationResult<Unit>
+typealias Constraint<T> = Validator<T, *>
 
 /**
  * Creates a text-based validation message.

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/Kova.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/Kova.kt
@@ -53,43 +53,43 @@ interface Kova {
     fun boolean(): IdentityValidator<Boolean> = generic()
 
     /** Creates a validator for String values with string-specific constraints. */
-    fun string(): StringValidator = generic()
+    fun string(): StringValidator<String> = generic()
 
     /** Creates a validator for Int values with numeric constraints. */
-    fun int(): NumberValidator<Int> = generic()
+    fun int(): NumberValidator<Int, Int> = generic()
 
     /** Creates a validator for Long values with numeric constraints. */
-    fun long(): NumberValidator<Long> = generic()
+    fun long(): NumberValidator<Long, Long> = generic()
 
     /** Creates a validator for Double values with numeric constraints. */
-    fun double(): NumberValidator<Double> = generic()
+    fun double(): NumberValidator<Double, Double> = generic()
 
     /** Creates a validator for Float values with numeric constraints. */
-    fun float(): NumberValidator<Float> = generic()
+    fun float(): NumberValidator<Float, Float> = generic()
 
     /** Creates a validator for Byte values with numeric constraints. */
-    fun byte(): NumberValidator<Byte> = generic()
+    fun byte(): NumberValidator<Byte, Byte> = generic()
 
     /** Creates a validator for Short values with numeric constraints. */
-    fun short(): NumberValidator<Short> = generic()
+    fun short(): NumberValidator<Short, Short> = generic()
 
     /** Creates a validator for BigDecimal values with numeric constraints. */
-    fun bigDecimal(): NumberValidator<BigDecimal> = generic()
+    fun bigDecimal(): NumberValidator<BigDecimal, BigDecimal> = generic()
 
     /** Creates a validator for BigInteger values with numeric constraints. */
-    fun bigInteger(): NumberValidator<BigInteger> = generic()
+    fun bigInteger(): NumberValidator<BigInteger, BigInteger> = generic()
 
     /** Creates a validator for UInt values with unsigned integer constraints. */
-    fun uInt(): NumberValidator<UInt> = generic()
+    fun uInt(): NumberValidator<UInt, UInt> = generic()
 
     /** Creates a validator for ULong values with unsigned integer constraints. */
-    fun uLong(): NumberValidator<ULong> = generic()
+    fun uLong(): NumberValidator<ULong, ULong> = generic()
 
     /** Creates a validator for UByte values with unsigned integer constraints. */
-    fun uByte(): NumberValidator<UByte> = generic()
+    fun uByte(): NumberValidator<UByte, UByte> = generic()
 
     /** Creates a validator for UShort values with unsigned integer constraints. */
-    fun uShort(): NumberValidator<UShort> = generic()
+    fun uShort(): NumberValidator<UShort, UShort> = generic()
 
     /**
      * Creates a validator for LocalDate values with temporal constraints.
@@ -110,7 +110,7 @@ interface Kova {
      * validator.tryValidate(LocalDate.of(2024, 12, 31), config = config)
      * ```
      */
-    fun localDate(): TemporalValidator<LocalDate> = generic()
+    fun localDate(): TemporalValidator<LocalDate, LocalDate> = generic()
 
     /**
      * Creates a validator for LocalTime values with temporal constraints.
@@ -118,7 +118,7 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun localTime(): TemporalValidator<LocalTime> = generic()
+    fun localTime(): TemporalValidator<LocalTime, LocalTime> = generic()
 
     /**
      * Creates a validator for LocalDateTime values with temporal constraints.
@@ -126,7 +126,7 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun localDateTime(): TemporalValidator<LocalDateTime> = generic()
+    fun localDateTime(): TemporalValidator<LocalDateTime, LocalDateTime> = generic()
 
     /**
      * Creates a validator for Instant values with temporal constraints.
@@ -134,7 +134,7 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun instant(): TemporalValidator<Instant> = generic()
+    fun instant(): TemporalValidator<Instant, Instant> = generic()
 
     /**
      * Creates a validator for MonthDay values.
@@ -143,7 +143,7 @@ interface Kova {
      * constraints (past, future, pastOrPresent, futureOrPresent). However, it does implement
      * [Comparable], so comparison constraints (min, max, gt, gte, lt, lte) are available.
      */
-    fun monthDay(): ComparableValidator<MonthDay> = generic()
+    fun monthDay(): ComparableValidator<MonthDay, MonthDay> = generic()
 
     /**
      * Creates a validator for OffsetDateTime values with temporal constraints.
@@ -151,7 +151,7 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun offsetDateTime(): TemporalValidator<OffsetDateTime> = generic()
+    fun offsetDateTime(): TemporalValidator<OffsetDateTime, OffsetDateTime> = generic()
 
     /**
      * Creates a validator for OffsetTime values with temporal constraints.
@@ -159,7 +159,7 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun offsetTime(): TemporalValidator<OffsetTime> = generic()
+    fun offsetTime(): TemporalValidator<OffsetTime, OffsetTime> = generic()
 
     /**
      * Creates a validator for Year values with temporal constraints.
@@ -167,7 +167,7 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun year(): TemporalValidator<Year> = generic()
+    fun year(): TemporalValidator<Year, Year> = generic()
 
     /**
      * Creates a validator for YearMonth values with temporal constraints.
@@ -175,7 +175,7 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun yearMonth(): TemporalValidator<YearMonth> = generic()
+    fun yearMonth(): TemporalValidator<YearMonth, YearMonth> = generic()
 
     /**
      * Creates a validator for ZonedDateTime values with temporal constraints.
@@ -183,19 +183,19 @@ interface Kova {
      * Temporal constraints use the clock from [ValidationConfig].
      * See [localDate] for clock configuration details.
      */
-    fun zonedDateTime(): TemporalValidator<ZonedDateTime> = generic()
+    fun zonedDateTime(): TemporalValidator<ZonedDateTime, ZonedDateTime> = generic()
 
     /** Creates a validator for Collection values with size and element validation. */
-    fun <E> collection(): CollectionValidator<Collection<E>> = generic()
+    fun <E> collection(): CollectionValidator<Collection<E>, Collection<E>> = generic()
 
     /** Creates a validator for List values with size and element validation. */
-    fun <E> list(): CollectionValidator<List<E>> = generic()
+    fun <E> list(): CollectionValidator<List<E>, List<E>> = generic()
 
     /** Creates a validator for Set values with size and element validation. */
-    fun <E> set(): CollectionValidator<Set<E>> = generic()
+    fun <E> set(): CollectionValidator<Set<E>, Set<E>> = generic()
 
     /** Creates a validator for Map values with size, key, and value validation. */
-    fun <K, V> map(): MapValidator<K, V> = generic()
+    fun <K, V> map(): MapValidator<Map<K, V>, K, V> = generic()
 
     /**
      * Creates a generic validator that accepts any value of type T.

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/MapValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/MapValidator.kt
@@ -5,10 +5,11 @@ package org.komapper.extension.validator
  *
  * Provides a convenient type for validators that work with Map types.
  *
+ * @param T The input type of the validator
  * @param K The key type of the map
  * @param V The value type of the map
  */
-typealias MapValidator<K, V> = IdentityValidator<Map<K, V>>
+typealias MapValidator<T, K, V> = Validator<T, Map<K, V>>
 
 /**
  * Validates that the map size is at least the specified minimum.
@@ -24,7 +25,7 @@ typealias MapValidator<K, V> = IdentityValidator<Map<K, V>>
  * @param message Custom error message provider
  * @return A new validator with the minimum size constraint
  */
-fun <K, V> MapValidator<K, V>.min(
+fun <T, K, V> MapValidator<T, K, V>.min(
     size: Int,
     message: LengthMessageProvider = { "kova.map.min".resource(it, size) },
 ) = constrain("kova.map.min") { satisfies(it.size >= size) { message(it.size) } }
@@ -43,7 +44,7 @@ fun <K, V> MapValidator<K, V>.min(
  * @param message Custom error message provider
  * @return A new validator with the maximum size constraint
  */
-fun <K, V> MapValidator<K, V>.max(
+fun <T, K, V> MapValidator<T, K, V>.max(
     size: Int,
     message: LengthMessageProvider = { "kova.map.max".resource(it, size) },
 ) = constrain("kova.map.max") { satisfies(it.size <= size) { message(it.size) } }
@@ -61,7 +62,7 @@ fun <K, V> MapValidator<K, V>.max(
  * @param message Custom error message provider
  * @return A new validator with the not-empty constraint
  */
-fun <K, V> MapValidator<K, V>.notEmpty(message: MessageProvider = { "kova.map.notEmpty".resource }) =
+fun <T, K, V> MapValidator<T, K, V>.notEmpty(message: MessageProvider = { "kova.map.notEmpty".resource }) =
     constrain("kova.map.notEmpty") { satisfies(it.isNotEmpty(), message) }
 
 /**
@@ -78,7 +79,7 @@ fun <K, V> MapValidator<K, V>.notEmpty(message: MessageProvider = { "kova.map.no
  * @param message Custom error message provider
  * @return A new validator with the exact size constraint
  */
-fun <K, V> MapValidator<K, V>.length(
+fun <T, K, V> MapValidator<T, K, V>.length(
     size: Int,
     message: LengthMessageProvider = { "kova.map.length".resource(it, size) },
 ) = constrain("kova.map.length") { satisfies(it.size == size) { message(it.size) } }
@@ -97,7 +98,7 @@ fun <K, V> MapValidator<K, V>.length(
  * @param message Custom error message provider
  * @return A new validator with the containsKey constraint
  */
-fun <K, V> MapValidator<K, V>.containsKey(
+fun <T, K, V> MapValidator<T, K, V>.containsKey(
     key: K,
     message: MessageProvider = { "kova.map.containsKey".resource(key) },
 ) = constrain("kova.map.containsKey") { satisfies(it.containsKey(key), message) }
@@ -116,7 +117,7 @@ fun <K, V> MapValidator<K, V>.containsKey(
  * @param message Custom error message provider
  * @return A new validator with the notContainsKey constraint
  */
-fun <K, V> MapValidator<K, V>.notContainsKey(
+fun <T, K, V> MapValidator<T, K, V>.notContainsKey(
     key: K,
     message: MessageProvider = { "kova.map.notContainsKey".resource(key) },
 ) = constrain("kova.map.notContainsKey") { satisfies(!it.containsKey(key), message) }
@@ -135,7 +136,7 @@ fun <K, V> MapValidator<K, V>.notContainsKey(
  * @param message Custom error message provider
  * @return A new validator with the containsValue constraint
  */
-fun <K, V> MapValidator<K, V>.containsValue(
+fun <T, K, V> MapValidator<T, K, V>.containsValue(
     value: V,
     message: MessageProvider = { "kova.map.containsValue".resource(value) },
 ) = constrain("kova.map.containsValue") { satisfies(it.containsValue(value), message) }
@@ -154,7 +155,7 @@ fun <K, V> MapValidator<K, V>.containsValue(
  * @param message Custom error message provider
  * @return A new validator with the notContainsValue constraint
  */
-fun <K, V> MapValidator<K, V>.notContainsValue(
+fun <T, K, V> MapValidator<T, K, V>.notContainsValue(
     value: V,
     message: MessageProvider = { "kova.map.notContainsValue".resource(value) },
 ) = constrain("kova.map.notContainsValue") { satisfies(!it.containsValue(value), message) }
@@ -180,7 +181,7 @@ fun <K, V> MapValidator<K, V>.notContainsValue(
  * @param validator The validator to apply to each entry
  * @return A new validator with per-entry validation
  */
-fun <K, V> MapValidator<K, V>.onEach(validator: Validator<Map.Entry<K, V>, *>) =
+fun <T, K, V> MapValidator<T, K, V>.onEach(validator: Constraint<Map.Entry<K, V>>) =
     constrain("kova.map.onEach") { appendPath(text = "<map entry>") { validateOnEach("kova.map.onEach", it, validator) } }
 
 /**
@@ -203,7 +204,7 @@ fun <K, V> MapValidator<K, V>.onEach(validator: Validator<Map.Entry<K, V>, *>) =
  * @param block A function that builds an entry validator from a success validator
  * @return A new validator with per-entry validation
  */
-fun <K, V> MapValidator<K, V>.onEach(block: (IdentityValidator<Map.Entry<K, V>>) -> Validator<Map.Entry<K, V>, *>) =
+fun <T, K, V> MapValidator<T, K, V>.onEach(block: (IdentityValidator<Map.Entry<K, V>>) -> Constraint<Map.Entry<K, V>>) =
     onEach(block(Validator.success()))
 
 /**
@@ -225,7 +226,7 @@ fun <K, V> MapValidator<K, V>.onEach(block: (IdentityValidator<Map.Entry<K, V>>)
  * @param validator The validator to apply to each key
  * @return A new validator with per-key validation
  */
-fun <K, V> MapValidator<K, V>.onEachKey(validator: Validator<K, *>) =
+fun <T, K, V> MapValidator<T, K, V>.onEachKey(validator: Constraint<K>) =
     constrain("kova.map.onEachKey") {
         validateOnEach("kova.map.onEachKey", it) { entry ->
             appendPath(text = "<map key>") { validator.execute(entry.key) }
@@ -251,7 +252,7 @@ fun <K, V> MapValidator<K, V>.onEachKey(validator: Validator<K, *>) =
  * @param block A function that builds a key validator from a success validator
  * @return A new validator with per-key validation
  */
-fun <K, V> MapValidator<K, V>.onEachKey(block: (IdentityValidator<K>) -> Validator<K, *>) = onEachKey(block(Validator.success()))
+fun <T, K, V> MapValidator<T, K, V>.onEachKey(block: (IdentityValidator<K>) -> Constraint<K>) = onEachKey(block(Validator.success()))
 
 /**
  * Validates each value of the map using the specified validator.
@@ -272,7 +273,7 @@ fun <K, V> MapValidator<K, V>.onEachKey(block: (IdentityValidator<K>) -> Validat
  * @param validator The validator to apply to each value
  * @return A new validator with per-value validation
  */
-fun <K, V> MapValidator<K, V>.onEachValue(validator: Validator<V, *>) =
+fun <T, K, V> MapValidator<T, K, V>.onEachValue(validator: Constraint<V>) =
     constrain("kova.map.onEachValue") {
         validateOnEach("kova.map.onEachValue", it) { entry ->
             appendPath(text = "[${entry.key}]<map value>") { validator.execute(entry.value) }
@@ -298,13 +299,13 @@ fun <K, V> MapValidator<K, V>.onEachValue(validator: Validator<V, *>) =
  * @param block A function that builds a value validator from a success validator
  * @return A new validator with per-value validation
  */
-fun <K, V> MapValidator<K, V>.onEachValue(block: (IdentityValidator<V>) -> Validator<V, *>) = onEachValue(block(Validator.success()))
+fun <T, K, V> MapValidator<T, K, V>.onEachValue(block: (IdentityValidator<V>) -> Constraint<V>) = onEachValue(block(Validator.success()))
 
 private fun <K, V> ValidationContext.validateOnEach(
     constraintId: String,
     map: Map<K, V>,
-    validate: Validator<Map.Entry<K, V>, *>,
-): ConstraintResult {
+    validate: Constraint<Map.Entry<K, V>>,
+): ValidationResult<Unit> {
     val failures = mutableListOf<ValidationResult.Failure<*>>()
     for (entry in map.entries) {
         val result = validate.execute(entry)

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/NumberValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/NumberValidator.kt
@@ -15,7 +15,7 @@ package org.komapper.extension.validator
  * val priceValidator: NumberValidator<Double> = Kova.double().notNegative()
  * ```
  */
-typealias NumberValidator<T> = IdentityValidator<T>
+typealias NumberValidator<T, S> = Validator<T, S>
 
 /**
  * Validates that the number is positive (greater than zero).
@@ -31,7 +31,7 @@ typealias NumberValidator<T> = IdentityValidator<T>
  * @param message Custom error message provider
  * @return A new validator with the positive constraint
  */
-fun <T : Number> NumberValidator<T>.positive(message: MessageProvider = { "kova.number.positive".resource }): NumberValidator<T> =
+fun <T, S : Number> NumberValidator<T, S>.positive(message: MessageProvider = { "kova.number.positive".resource }) =
     constrain("kova.number.positive") { satisfies(it.toDouble() > 0.0, message) }
 
 /**
@@ -48,7 +48,7 @@ fun <T : Number> NumberValidator<T>.positive(message: MessageProvider = { "kova.
  * @param message Custom error message provider
  * @return A new validator with the negative constraint
  */
-fun <T : Number> NumberValidator<T>.negative(message: MessageProvider = { "kova.number.negative".resource }): NumberValidator<T> =
+fun <T, S : Number> NumberValidator<T, S>.negative(message: MessageProvider = { "kova.number.negative".resource }) =
     constrain("kova.number.negative") { satisfies(it.toDouble() < 0.0, message) }
 
 /**
@@ -65,7 +65,7 @@ fun <T : Number> NumberValidator<T>.negative(message: MessageProvider = { "kova.
  * @param message Custom error message provider
  * @return A new validator with the not-positive constraint
  */
-fun <T : Number> NumberValidator<T>.notPositive(message: MessageProvider = { "kova.number.notPositive".resource }): NumberValidator<T> =
+fun <T, S : Number> NumberValidator<T, S>.notPositive(message: MessageProvider = { "kova.number.notPositive".resource }) =
     constrain("kova.number.notPositive") { satisfies(it.toDouble() <= 0.0, message) }
 
 /**
@@ -82,5 +82,5 @@ fun <T : Number> NumberValidator<T>.notPositive(message: MessageProvider = { "ko
  * @param message Custom error message provider
  * @return A new validator with the not-negative constraint
  */
-fun <T : Number> NumberValidator<T>.notNegative(message: MessageProvider = { "kova.number.notNegative".resource }): NumberValidator<T> =
+fun <T, S : Number> NumberValidator<T, S>.notNegative(message: MessageProvider = { "kova.number.notNegative".resource }) =
     constrain("kova.number.notNegative") { satisfies(it.toDouble() >= 0.0, message) }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/StringValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/StringValidator.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KClass
  *
  * Provides a convenient type for validators that work with String inputs and outputs.
  */
-typealias StringValidator = IdentityValidator<String>
+typealias StringValidator<T> = Validator<T, String>
 
 /**
  * Validates that the string can be parsed as an Int.
@@ -23,8 +23,8 @@ typealias StringValidator = IdentityValidator<String>
  * @param message Custom error message provider
  * @return A new validator with the is-int constraint
  */
-fun StringValidator.isInt(message: MessageProvider = { "kova.string.isInt".resource }) =
-    constrain("kova.string.isInt") { satisfies(it.toIntOrNull() != null, message) }
+fun <T> StringValidator<T>.isInt(message: MessageProvider = { "kova.string.isInt".resource }) =
+    constrain("kova.string.isInt", Kova.string().toInt(message))
 
 /**
  * Validates that the string can be parsed as a Long.
@@ -39,8 +39,8 @@ fun StringValidator.isInt(message: MessageProvider = { "kova.string.isInt".resou
  * @param message Custom error message provider
  * @return A new validator with the is-long constraint
  */
-fun StringValidator.isLong(message: MessageProvider = { "kova.string.isLong".resource }) =
-    constrain("kova.string.isLong") { satisfies(it.toLongOrNull() != null, message) }
+fun <T> StringValidator<T>.isLong(message: MessageProvider = { "kova.string.isLong".resource }) =
+    constrain("kova.string.isLong", Kova.string().toLong(message))
 
 /**
  * Validates that the string can be parsed as a Short.
@@ -55,8 +55,8 @@ fun StringValidator.isLong(message: MessageProvider = { "kova.string.isLong".res
  * @param message Custom error message provider
  * @return A new validator with the is-short constraint
  */
-fun StringValidator.isShort(message: MessageProvider = { "kova.string.isShort".resource }) =
-    constrain("kova.string.isShort") { satisfies(it.toShortOrNull() != null, message) }
+fun <T> StringValidator<T>.isShort(message: MessageProvider = { "kova.string.isShort".resource }) =
+    constrain("kova.string.isShort", Kova.string().toShort(message))
 
 /**
  * Validates that the string can be parsed as a Byte.
@@ -71,8 +71,8 @@ fun StringValidator.isShort(message: MessageProvider = { "kova.string.isShort".r
  * @param message Custom error message provider
  * @return A new validator with the is-byte constraint
  */
-fun StringValidator.isByte(message: MessageProvider = { "kova.string.isByte".resource }) =
-    constrain("kova.string.isByte") { satisfies(it.toByteOrNull() != null, message) }
+fun <T> StringValidator<T>.isByte(message: MessageProvider = { "kova.string.isByte".resource }) =
+    constrain("kova.string.isByte", Kova.string().toByte(message))
 
 /**
  * Validates that the string can be parsed as a Double.
@@ -87,8 +87,8 @@ fun StringValidator.isByte(message: MessageProvider = { "kova.string.isByte".res
  * @param message Custom error message provider
  * @return A new validator with the is-double constraint
  */
-fun StringValidator.isDouble(message: MessageProvider = { "kova.string.isDouble".resource }) =
-    constrain("kova.string.isDouble") { satisfies(it.toDoubleOrNull() != null, message) }
+fun <T> StringValidator<T>.isDouble(message: MessageProvider = { "kova.string.isDouble".resource }) =
+    constrain("kova.string.isDouble", Kova.string().toDouble(message))
 
 /**
  * Validates that the string can be parsed as a Float.
@@ -103,8 +103,8 @@ fun StringValidator.isDouble(message: MessageProvider = { "kova.string.isDouble"
  * @param message Custom error message provider
  * @return A new validator with the is-float constraint
  */
-fun StringValidator.isFloat(message: MessageProvider = { "kova.string.isFloat".resource }) =
-    constrain("kova.string.isFloat") { satisfies(it.toFloatOrNull() != null, message) }
+fun <T> StringValidator<T>.isFloat(message: MessageProvider = { "kova.string.isFloat".resource }) =
+    constrain("kova.string.isFloat", Kova.string().toFloat(message))
 
 /**
  * Validates that the string can be parsed as a BigDecimal.
@@ -119,8 +119,8 @@ fun StringValidator.isFloat(message: MessageProvider = { "kova.string.isFloat".r
  * @param message Custom error message provider
  * @return A new validator with the is-big-decimal constraint
  */
-fun StringValidator.isBigDecimal(message: MessageProvider = { "kova.string.isBigDecimal".resource }) =
-    constrain("kova.string.isBigDecimal") { satisfies(it.toBigDecimalOrNull() != null, message) }
+fun <T> StringValidator<T>.isBigDecimal(message: MessageProvider = { "kova.string.isBigDecimal".resource }) =
+    constrain("kova.string.isBigDecimal", Kova.string().toBigDecimal(message))
 
 /**
  * Validates that the string can be parsed as a BigInteger.
@@ -135,8 +135,8 @@ fun StringValidator.isBigDecimal(message: MessageProvider = { "kova.string.isBig
  * @param message Custom error message provider
  * @return A new validator with the is-big-integer constraint
  */
-fun StringValidator.isBigInteger(message: MessageProvider = { "kova.string.isBigInteger".resource }) =
-    constrain("kova.string.isBigInteger") { satisfies(it.toBigIntegerOrNull() != null, message) }
+fun <T> StringValidator<T>.isBigInteger(message: MessageProvider = { "kova.string.isBigInteger".resource }) =
+    constrain("kova.string.isBigInteger", Kova.string().toBigInteger(message))
 
 /**
  * Validates that the string can be parsed as a Boolean.
@@ -154,8 +154,8 @@ fun StringValidator.isBigInteger(message: MessageProvider = { "kova.string.isBig
  * @param message Custom error message provider
  * @return A new validator with the is-boolean constraint
  */
-fun StringValidator.isBoolean(message: MessageProvider = { "kova.string.isBoolean".resource }) =
-    constrain("kova.string.isBoolean") { satisfies(it.toBooleanStrictOrNull() != null, message) }
+fun <T> StringValidator<T>.isBoolean(message: MessageProvider = { "kova.string.isBoolean".resource }) =
+    constrain("kova.string.isBoolean", Kova.string().toBoolean(message))
 
 /**
  * Validates that the string is a valid name for the specified enum type.
@@ -172,14 +172,10 @@ fun StringValidator.isBoolean(message: MessageProvider = { "kova.string.isBoolea
  * @param message Custom error message provider
  * @return A new validator with the is-enum constraint
  */
-fun <E : Enum<E>> StringValidator.isEnum(
+fun <E : Enum<E>, T> StringValidator<T>.isEnum(
     klass: KClass<E>,
     message: ValidationContext.(validNames: List<String>) -> Message = { "kova.string.isEnum".resource(it) },
-): StringValidator {
-    val enumValues = klass.java.enumConstants
-    val validNames = enumValues.map { it.name }
-    return constrain("kova.string.isEnum") { satisfies(validNames.contains(it)) { message(validNames) } }
-}
+) = constrain("kova.string.isEnum", Kova.string().toEnum(klass, message))
 
 /**
  * Validates that the string is a valid name for the specified enum type (reified version).
@@ -195,9 +191,9 @@ fun <E : Enum<E>> StringValidator.isEnum(
  * @param message Custom error message provider
  * @return A new validator with the is-enum constraint
  */
-inline fun <reified E : Enum<E>> StringValidator.isEnum(
+inline fun <reified E : Enum<E>, T> StringValidator<T>.isEnum(
     noinline message: ValidationContext.(validNames: List<String>) -> Message = { "kova.string.isEnum".resource(it) },
-): StringValidator = isEnum(E::class, message)
+) = isEnum(E::class, message)
 
 /**
  * Validates that the string is a valid enum name and converts it to the enum value.
@@ -214,7 +210,19 @@ inline fun <reified E : Enum<E>> StringValidator.isEnum(
  *
  * @return A new validator that transforms string to enum type
  */
-inline fun <reified E : Enum<E>> StringValidator.toEnum(): Validator<String, E> = isEnum<E>().map { enumValueOf<E>(it) }
+inline fun <reified E : Enum<E>, T> StringValidator<T>.toEnum(
+    noinline message: ValidationContext.(validNames: List<String>) -> Message = { "kova.string.isEnum".resource(it) },
+) = toEnum(E::class, message)
+
+fun <E : Enum<E>, T> StringValidator<T>.toEnum(
+    klass: KClass<E>,
+    message: ValidationContext.(validNames: List<String>) -> Message = { "kova.string.isEnum".resource(it) },
+): Validator<T, E> =
+    then {
+        runCatching { java.lang.Enum.valueOf(klass.java, it) }.getOrNull().satisfiesNotNull {
+            message(klass.java.enumConstants.map { enum -> enum.name })
+        }
+    }
 
 /**
  * Validates that the string is in uppercase.
@@ -229,7 +237,7 @@ inline fun <reified E : Enum<E>> StringValidator.toEnum(): Validator<String, E> 
  * @param message Custom error message provider
  * @return A new validator with the uppercase constraint
  */
-fun StringValidator.uppercase(message: MessageProvider = { "kova.string.uppercase".resource }) =
+fun <T> StringValidator<T>.uppercase(message: MessageProvider = { "kova.string.uppercase".resource }) =
     constrain("kova.string.uppercase") { satisfies(it == it.uppercase(), message) }
 
 /**
@@ -245,7 +253,7 @@ fun StringValidator.uppercase(message: MessageProvider = { "kova.string.uppercas
  * @param message Custom error message provider
  * @return A new validator with the lowercase constraint
  */
-fun StringValidator.lowercase(message: MessageProvider = { "kova.string.lowercase".resource }) =
+fun <T> StringValidator<T>.lowercase(message: MessageProvider = { "kova.string.lowercase".resource }) =
     constrain("kova.string.lowercase") { satisfies(it == it.lowercase(), message) }
 
 /**
@@ -259,7 +267,7 @@ fun StringValidator.lowercase(message: MessageProvider = { "kova.string.lowercas
  *
  * @return A new validator that trims the string
  */
-fun StringValidator.trim() = map { it.trim() }
+fun <T> StringValidator<T>.trim() = map { it.trim() }
 
 /**
  * Transforms the string to uppercase.
@@ -272,7 +280,7 @@ fun StringValidator.trim() = map { it.trim() }
  *
  * @return A new validator that transforms to uppercase
  */
-fun StringValidator.toUppercase() = map { it.uppercase() }
+fun <T> StringValidator<T>.toUppercase() = map { it.uppercase() }
 
 /**
  * Transforms the string to lowercase.
@@ -285,7 +293,7 @@ fun StringValidator.toUppercase() = map { it.uppercase() }
  *
  * @return A new validator that transforms to lowercase
  */
-fun StringValidator.toLowercase() = map { it.lowercase() }
+fun <T> StringValidator<T>.toLowercase() = map { it.lowercase() }
 
 /**
  * Validates that the string can be parsed as an Int and converts it.
@@ -301,7 +309,8 @@ fun StringValidator.toLowercase() = map { it.lowercase() }
  *
  * @return A new validator that transforms string to Int
  */
-fun StringValidator.toInt(): Validator<String, Int> = isInt().map { it.toInt() }
+fun <T> StringValidator<T>.toInt(message: MessageProvider = { "kova.string.isInt".resource }) =
+    then { it.toIntOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a Long and converts it.
@@ -317,7 +326,8 @@ fun StringValidator.toInt(): Validator<String, Int> = isInt().map { it.toInt() }
  *
  * @return A new validator that transforms string to Long
  */
-fun StringValidator.toLong(): Validator<String, Long> = isLong().map { it.toLong() }
+fun <T> StringValidator<T>.toLong(message: MessageProvider = { "kova.string.isLong".resource }) =
+    then { it.toLongOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a Short and converts it.
@@ -333,7 +343,8 @@ fun StringValidator.toLong(): Validator<String, Long> = isLong().map { it.toLong
  *
  * @return A new validator that transforms string to Short
  */
-fun StringValidator.toShort(): Validator<String, Short> = isShort().map { it.toShort() }
+fun <T> StringValidator<T>.toShort(message: MessageProvider = { "kova.string.isShort".resource }) =
+    then { it.toShortOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a Byte and converts it.
@@ -349,7 +360,8 @@ fun StringValidator.toShort(): Validator<String, Short> = isShort().map { it.toS
  *
  * @return A new validator that transforms string to Byte
  */
-fun StringValidator.toByte(): Validator<String, Byte> = isByte().map { it.toByte() }
+fun <T> StringValidator<T>.toByte(message: MessageProvider = { "kova.string.isByte".resource }) =
+    then { it.toByteOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a Double and converts it.
@@ -365,7 +377,8 @@ fun StringValidator.toByte(): Validator<String, Byte> = isByte().map { it.toByte
  *
  * @return A new validator that transforms string to Double
  */
-fun StringValidator.toDouble(): Validator<String, Double> = isDouble().map { it.toDouble() }
+fun <T> StringValidator<T>.toDouble(message: MessageProvider = { "kova.string.isDouble".resource }) =
+    then { it.toDoubleOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a Float and converts it.
@@ -381,7 +394,8 @@ fun StringValidator.toDouble(): Validator<String, Double> = isDouble().map { it.
  *
  * @return A new validator that transforms string to Float
  */
-fun StringValidator.toFloat(): Validator<String, Float> = isFloat().map { it.toFloat() }
+fun <T> StringValidator<T>.toFloat(message: MessageProvider = { "kova.string.isFloat".resource }) =
+    then { it.toFloatOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a BigDecimal and converts it.
@@ -397,7 +411,8 @@ fun StringValidator.toFloat(): Validator<String, Float> = isFloat().map { it.toF
  *
  * @return A new validator that transforms string to BigDecimal
  */
-fun StringValidator.toBigDecimal(): Validator<String, java.math.BigDecimal> = isBigDecimal().map { it.toBigDecimal() }
+fun <T> StringValidator<T>.toBigDecimal(message: MessageProvider = { "kova.string.isBigDecimal".resource }) =
+    then { it.toBigDecimalOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a BigInteger and converts it.
@@ -413,7 +428,8 @@ fun StringValidator.toBigDecimal(): Validator<String, java.math.BigDecimal> = is
  *
  * @return A new validator that transforms string to BigInteger
  */
-fun StringValidator.toBigInteger(): Validator<String, java.math.BigInteger> = isBigInteger().map { it.toBigInteger() }
+fun <T> StringValidator<T>.toBigInteger(message: MessageProvider = { "kova.string.isBigInteger".resource }) =
+    then { it.toBigIntegerOrNull().satisfiesNotNull(message) }
 
 /**
  * Validates that the string can be parsed as a Boolean and converts it.
@@ -430,4 +446,5 @@ fun StringValidator.toBigInteger(): Validator<String, java.math.BigInteger> = is
  *
  * @return A new validator that transforms string to Boolean
  */
-fun StringValidator.toBoolean(): Validator<String, Boolean> = isBoolean().map { it.toBoolean() }
+fun <T> StringValidator<T>.toBoolean(message: MessageProvider = { "kova.string.isBoolean".resource }) =
+    then { it.toBooleanStrictOrNull().satisfiesNotNull(message) }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/TemporalValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/TemporalValidator.kt
@@ -34,7 +34,7 @@ import kotlin.reflect.KClass
  * validator.tryValidate(LocalDate.of(2024, 12, 31), config = config)
  * ```
  */
-typealias TemporalValidator<T> = IdentityValidator<T>
+typealias TemporalValidator<T, S> = Validator<T, S>
 
 /**
  * Validates that the temporal value is in the future (strictly greater than now).
@@ -54,10 +54,10 @@ typealias TemporalValidator<T> = IdentityValidator<T>
  * @param message Custom error message provider
  * @return A new validator with the future constraint
  */
-inline fun <reified T> TemporalValidator<T>.future(
+inline fun <T, reified S> TemporalValidator<T, S>.future(
     noinline message: MessageProvider = { "kova.temporal.future".resource },
-): TemporalValidator<T>
-        where T : Temporal, T : Comparable<T> =
+): TemporalValidator<T, S>
+        where S : Temporal, S : Comparable<S> =
     constrain("kova.temporal.future") { satisfies(it > now(clock), message) }
 
 /**
@@ -78,10 +78,10 @@ inline fun <reified T> TemporalValidator<T>.future(
  * @param message Custom error message provider
  * @return A new validator with the future-or-present constraint
  */
-inline fun <reified T> TemporalValidator<T>.futureOrPresent(
+inline fun <T, reified S> TemporalValidator<T, S>.futureOrPresent(
     noinline message: MessageProvider = { "kova.temporal.futureOrPresent".resource },
-): TemporalValidator<T>
-        where T : Temporal, T : Comparable<T> =
+): TemporalValidator<T, S>
+        where S : Temporal, S : Comparable<S> =
     constrain("kova.temporal.futureOrPresent") { satisfies(it >= now(clock), message) }
 
 /**
@@ -102,10 +102,10 @@ inline fun <reified T> TemporalValidator<T>.futureOrPresent(
  * @param message Custom error message provider
  * @return A new validator with the past constraint
  */
-inline fun <reified T> TemporalValidator<T>.past(
+inline fun <T, reified S> TemporalValidator<T, S>.past(
     noinline message: MessageProvider = { "kova.temporal.past".resource },
-): TemporalValidator<T>
-        where T : Temporal, T : Comparable<T> =
+): TemporalValidator<T, S>
+        where S : Temporal, S : Comparable<S> =
     constrain("kova.temporal.past") { satisfies(it < now(clock), message) }
 
 /**
@@ -126,10 +126,10 @@ inline fun <reified T> TemporalValidator<T>.past(
  * @param message Custom error message provider
  * @return A new validator with the past-or-present constraint
  */
-inline fun <reified T> TemporalValidator<T>.pastOrPresent(
+inline fun <T, reified S> TemporalValidator<T, S>.pastOrPresent(
     noinline message: MessageProvider = { "kova.temporal.pastOrPresent".resource },
-): TemporalValidator<T>
-        where T : Temporal, T : Comparable<T> =
+): TemporalValidator<T, S>
+        where S : Temporal, S : Comparable<S> =
     constrain("kova.temporal.pastOrPresent") { satisfies(it <= now(clock), message) }
 
 /**

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/ValidationContext.kt
@@ -71,12 +71,14 @@ data class ValidationContext(
     fun satisfies(
         condition: Boolean,
         message: MessageProvider,
-    ): ConstraintResult =
+    ): ValidationResult<Unit> =
         if (condition) {
             ValidationResult.Success(Unit)
         } else {
-            ValidationResult.Failure(Input.Available(Unit), listOf(message()))
+            ValidationResult.Failed(listOf(message()))
         }
+
+    fun <A> A.satisfiesNotNull(message: MessageProvider): ValidationResult<A & Any> = satisfies(this != null, message).map { this!! }
 
     /**
      * Creates a resource-based validation message.
@@ -243,9 +245,12 @@ inline fun <R> ValidationContext.addPath(
  * @param obj The object to bind to the current path
  * @return A new context with the updated object reference
  */
-fun ValidationContext.bindObject(obj: Any?): ValidationContext {
+inline fun <R> ValidationContext.bindObject(
+    obj: Any?,
+    block: ValidationContext.() -> R,
+): R {
     val path = this.path.copy(obj = obj)
-    return copy(path = path)
+    return block(copy(path = path))
 }
 
 /**

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/CharSequenceValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/CharSequenceValidatorTest.kt
@@ -42,13 +42,13 @@ class CharSequenceValidatorTest :
             }
         }
 
-        context("chain") {
+        context("then") {
             val length = Kova.string().length(3)
             val validator =
                 Kova
                     .string()
                     .trim()
-                    .chain(length)
+                    .then(length)
                     .toUppercase()
 
             test("success") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/IdentityValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/IdentityValidatorTest.kt
@@ -141,7 +141,7 @@ class IdentityValidatorTest :
         }
 
         context("constrain with extension function") {
-            fun IdentityValidator<Int>.even() = constrain("even") { satisfies(it % 2 == 0) { text("input must be even") } }
+            fun <T> Validator<T, Int>.even() = constrain("even") { satisfies(it % 2 == 0) { text("input must be even") } }
             val validator = Kova.int().even()
 
             test("failure") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaPropertiesTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/KovaPropertiesTest.kt
@@ -793,7 +793,7 @@ class KovaPropertiesTest :
             }
 
             test("isEnum") {
-                val result = Kova.string().isEnum<TestEnum>().tryValidate("INVALID")
+                val result = Kova.string().isEnum<TestEnum, _>().tryValidate("INVALID")
                 result.isFailure().mustBeTrue()
                 val message = result.messages.single()
                 message.text shouldBe "must be one of: [A, B, C]"

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
@@ -308,7 +308,12 @@ class NullableValidatorTest :
         }
 
         context("toNonNullable - then") {
-            val notNullAndMin3AndMax3 = Kova.nullable<Int>().toNonNullable().then { it.max(5).min(3) }
+            val notNullAndMin3AndMax3 =
+                Kova
+                    .nullable<Int>()
+                    .toNonNullable()
+                    .max(5)
+                    .min(3)
 
             test("success") {
                 val result = notNullAndMin3AndMax3.tryValidate(4)

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
@@ -527,7 +527,7 @@ class StringValidatorTest :
         }
 
         context("isEnum with Type") {
-            val isEnum = Kova.string().isEnum<Status>()
+            val isEnum = Kova.string().isEnum<Status, _>()
 
             test("success with ACTIVE") {
                 val result = isEnum.tryValidate("ACTIVE")
@@ -587,7 +587,7 @@ class StringValidatorTest :
         }
 
         context("toEnum") {
-            val toEnum = Kova.string().toEnum<Status>()
+            val toEnum = Kova.string().toEnum<Status, _>()
 
             test("success with ACTIVE") {
                 val result = toEnum.tryValidate("ACTIVE")

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
@@ -236,7 +236,7 @@ class ValidatorTest :
                     .int()
                     .min(3)
                     .map { it.toString() }
-                    .then { it.max(1) }
+                    .max(1)
             test("success") {
                 val result = validator.tryValidate(3)
                 result.isSuccess().mustBeTrue()

--- a/kova-factory/src/test/kotlin/org/komapper/extension/validator/factory/FactoryTest.kt
+++ b/kova-factory/src/test/kotlin/org/komapper/extension/validator/factory/FactoryTest.kt
@@ -114,8 +114,8 @@ class FactoryTest :
                 first: String,
                 last: String,
             ) = Kova.factory {
-                val first by bind(createNameFactory(first))
-                val last by bind(createNameFactory(last))
+                val first by createNameFactory(first)
+                val last by createNameFactory(last)
                 create { FullName(first(), last()) }
             }
 
@@ -128,7 +128,7 @@ class FactoryTest :
                 Kova
                     .factory {
                         val id by bind(id) { it.toInt() }
-                        val fullName by bind(createFullNameFactory(firstName, lastName))
+                        val fullName by createFullNameFactory(firstName, lastName)
                         create { User(id(), fullName()) }
                     }.tryCreate(config)
 


### PR DESCRIPTION
Depends on #74
This changes the implementation details around `Failure`, making it really obvious when errors are and aren't accumulated. `map`, `then`, et al now accumulate errors by default. 
With the changes, it became clear that `IdentityValidator` was being overused, resulting in `then` calls being needed whenever a validator didn't conform to `IdentityValidator`. The reality is that most, if not all, constraints should operate on the generic `Validator`, and only care about its output type. 