### PR TITLE
Add Japanese localization support

### DIFF
--- a/example-core/src/test/kotlin/example/core/MainTest.kt
+++ b/example-core/src/test/kotlin/example/core/MainTest.kt
@@ -46,11 +46,11 @@ class MainTest :
                 val result = tryValidate { validate(user) }
 
                 result.shouldBeFailure()
-                val messages = result.messages.map { it.text }
-                messages.size shouldBe 3
-                messages.any { it.contains("at least 1 characters") } shouldBe true
-                messages.any { it.contains("must not be blank") } shouldBe true
-                messages.any { it.contains("greater than or equal to 0") } shouldBe true
+                val ids = result.messages.map { it.constraintId }
+                ids.size shouldBe 3
+                ids[0] shouldBe "kova.charSequence.minLength"
+                ids[1] shouldBe "kova.charSequence.notBlank"
+                ids[2] shouldBe "kova.comparable.min"
             }
 
             test("failure - age exceeds maximum") {
@@ -58,8 +58,9 @@ class MainTest :
                 val result = tryValidate { validate(user) }
 
                 result.shouldBeFailure()
-                val messages = result.messages.map { it.text }
-                messages.any { it.contains("less than or equal to 120") } shouldBe true
+                val ids = result.messages.map { it.constraintId }
+                ids.size shouldBe 1
+                ids[0] shouldBe "kova.comparable.max"
             }
         }
 

--- a/kova-core/src/main/resources/kova_ja.properties
+++ b/kova-core/src/main/resources/kova_ja.properties
@@ -1,0 +1,77 @@
+kova.charSequence.minLength={0}文字以上である必要があります
+kova.charSequence.maxLength={0}文字以下である必要があります
+kova.charSequence.length=ちょうど{0}文字である必要があります
+kova.charSequence.notBlank=空白であってはいけません
+kova.charSequence.blank=空白である必要があります
+kova.charSequence.notEmpty=空であってはいけません
+kova.charSequence.empty=空である必要があります
+kova.charSequence.startsWith="{0}"で始まる必要があります
+kova.charSequence.notStartsWith="{0}"で始まってはいけません
+kova.charSequence.endsWith="{0}"で終わる必要があります
+kova.charSequence.notEndsWith="{0}"で終わってはいけません
+kova.charSequence.contains="{0}"を含む必要があります
+kova.charSequence.notContains="{0}"を含んではいけません
+kova.charSequence.matches=パターン{0}に一致する必要があります
+kova.charSequence.notMatches=パターン{0}に一致してはいけません
+
+kova.collection.minSize=コレクション(サイズ{0})は少なくとも{1}個の要素を持つ必要があります
+kova.collection.maxSize=コレクション(サイズ{0})は最大{1}個の要素を持つ必要があります
+kova.collection.size=コレクション(サイズ{0})はちょうど{1}個の要素を持つ必要があります
+kova.collection.onEach=一部の要素が制約を満たしていません: {0}
+kova.collection.notEmpty=空であってはいけません
+kova.collection.contains={0}を含む必要があります
+kova.collection.notContains={0}を含んではいけません
+
+kova.comparable.min={0}以上である必要があります
+kova.comparable.max={0}以下である必要があります
+kova.comparable.gt={0}より大きい必要があります
+kova.comparable.gte={0}以上である必要があります
+kova.comparable.lt={0}より小さい必要があります
+kova.comparable.lte={0}以下である必要があります
+kova.comparable.eq={0}と等しい必要があります
+kova.comparable.notEq={0}と等しくない必要があります
+
+kova.literal.single={0}である必要があります
+kova.literal.list=次のいずれかである必要があります: {0}
+
+kova.map.minSize=マップ(サイズ{0})は少なくとも{1}個のエントリを持つ必要があります
+kova.map.maxSize=マップ(サイズ{0})は最大{1}個のエントリを持つ必要があります
+kova.map.size=マップ(サイズ{0})はちょうど{1}個のエントリを持つ必要があります
+kova.map.onEach=一部のエントリが制約を満たしていません: {0}
+kova.map.onEachKey=一部のキーが制約を満たしていません: {0}
+kova.map.onEachValue=一部の値が制約を満たしていません: {0}
+kova.map.notEmpty=空であってはいけません
+kova.map.containsKey=キー{0}を含む必要があります
+kova.map.notContainsKey=キー{0}を含んではいけません
+kova.map.containsValue=値{0}を含む必要があります
+kova.map.notContainsValue=値{0}を含んではいけません
+
+kova.nullable.isNull=nullである必要があります
+kova.nullable.notNull=nullであってはいけません
+
+kova.number.positive=正の数である必要があります
+kova.number.negative=負の数である必要があります
+kova.number.notPositive=正の数であってはいけません
+kova.number.notNegative=負の数であってはいけません
+
+kova.or=少なくとも1つの制約を満たす必要があります: [{0}, {1}]
+
+kova.string.isInt=有効な整数である必要があります
+kova.string.isLong=有効なlong型の整数である必要があります
+kova.string.isShort=有効なshort型の整数である必要があります
+kova.string.isByte=有効なbyte型の整数である必要があります
+kova.string.isDouble=有効なdouble型の数値である必要があります
+kova.string.isFloat=有効なfloat型の数値である必要があります
+kova.string.isBigDecimal=有効な10進数である必要があります
+kova.string.isBigInteger=有効な整数である必要があります
+kova.string.isBoolean="true"または"false"である必要があります
+kova.string.isEnum=次のいずれかである必要があります: {0}
+kova.string.uppercase=大文字である必要があります
+kova.string.lowercase=小文字である必要があります
+
+kova.temporal.future=未来の日時である必要があります
+kova.temporal.futureOrPresent=未来または現在の日時である必要があります
+kova.temporal.past=過去の日時である必要があります
+kova.temporal.pastOrPresent=過去または現在の日時である必要があります
+
+kova.withMessage=無効な値: {0}

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/CharSequenceValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/CharSequenceValidatorTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class CharSequenceValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("with conversion") {
             fun Validation.validate(string: String) =

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/CollectionValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/CollectionValidatorTest.kt
@@ -2,9 +2,14 @@ package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.Locale
 
 class CollectionValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("notEmpty") {
             test("success") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ComparableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ComparableValidatorTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class ComparableValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("uInt") {
             context("min") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ConditionalTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ConditionalTest.kt
@@ -2,9 +2,14 @@ package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.Locale
 
 class ConditionalTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("if expression") {
             fun Validation.validate(i: Int) {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/LiteralValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/LiteralValidatorTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class LiteralValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("literal") {
             context("boolean") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/MapValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/MapValidatorTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class MapValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("maxSize") {
             test("success") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/MessagePropertiesJaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/MessagePropertiesJaTest.kt
@@ -1,0 +1,30 @@
+package org.komapper.extension.validator
+
+import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
+
+class MessagePropertiesJaTest :
+    FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.JAPAN)
+        }
+
+        context("kova.charSequence") {
+            test("minLength") {
+                val result = tryValidate { minLength("abc", 5) }
+                result.shouldBeFailure()
+                val message = result.messages.single()
+                message.text shouldBe "5文字以上である必要があります"
+            }
+        }
+
+        context("kova.collection") {
+            test("minSize") {
+                val result = tryValidate { minSize(listOf("a", "b"), 3) }
+                result.shouldBeFailure()
+                val message = result.messages.single()
+                message.text shouldBe "コレクション(サイズ2)は少なくとも3個の要素を持つ必要があります"
+            }
+        }
+    })

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/MessagePropertiesTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/MessagePropertiesTest.kt
@@ -2,33 +2,38 @@ package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
 import java.time.LocalDate
+import java.util.Locale
 
 class MessagePropertiesTest :
     FunSpec({
 
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
+
         context("kova.charSequence") {
-            test("min") {
+            test("minLength") {
                 val result = tryValidate { minLength("abc", 5) }
                 result.shouldBeFailure()
                 val message = result.messages.single()
                 message.text shouldBe "must be at least 5 characters"
             }
 
-            test("min with message") {
+            test("minLength with message") {
                 val result = tryValidate { minLength("abc", 5) { text("must be at least 5 characters") } }
                 result.shouldBeFailure()
                 val message = result.messages.single()
                 message.text shouldBe "must be at least 5 characters"
             }
 
-            test("max") {
+            test("maxLength") {
                 val result = tryValidate { maxLength("abcdef", 5) }
                 result.shouldBeFailure()
                 val message = result.messages.single()
                 message.text shouldBe "must be at most 5 characters"
             }
 
-            test("max with message") {
+            test("maxLength with message") {
                 val result = tryValidate { maxLength("abcdef", 5) { text("must be at most 5 characters") } }
                 result.shouldBeFailure()
                 val message = result.messages.single()

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/MessageProviderTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/MessageProviderTest.kt
@@ -1,9 +1,15 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class MessageProviderTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
+
         context("MessageProvider") {
             val input = "abc"
 

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/MessageTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/MessageTest.kt
@@ -2,9 +2,14 @@ package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
 import java.text.MessageFormat
+import java.util.Locale
 
 class MessageTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         test("getPattern") {
             val pattern = getPattern("kova.comparable.min")

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NullableValidatorTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class NullableValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("nullable") {
             test("success with null value") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/NumberValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/NumberValidatorTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class NumberValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("positive") {
             test("success with positive number") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/SchemaCircularReferenceTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/SchemaCircularReferenceTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class SchemaCircularReferenceTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         test("circular reference between schemas") {
             val users = mutableListOf<User>()

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/SchemaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/SchemaTest.kt
@@ -4,9 +4,14 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import java.time.LocalDate
+import java.util.Locale
 
 class SchemaTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         data class User(
             val id: Int,

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
@@ -1,9 +1,14 @@
 package org.komapper.extension.validator
 
 import io.kotest.core.spec.style.FunSpec
+import java.util.Locale
 
 class StringValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("notBlank with message") {
             test("success") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/TemporalValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/TemporalValidatorTest.kt
@@ -13,9 +13,14 @@ import java.time.Year
 import java.time.YearMonth
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.util.Locale
 
 class TemporalValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("LocalDate") {
             val date = LocalDate.of(2025, 1, 1)

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidationTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidationTest.kt
@@ -3,6 +3,7 @@ package org.komapper.extension.validator
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import java.util.Locale
 
 data class TestData(
     val value: String,
@@ -10,6 +11,10 @@ data class TestData(
 
 class ValidationContextTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("addRoot") {
             test("no root") {

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidatorTest.kt
@@ -3,9 +3,14 @@ package org.komapper.extension.validator
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.Locale
 
 class ValidatorTest :
     FunSpec({
+
+        beforeSpec {
+            Locale.setDefault(Locale.US)
+        }
 
         context("tryValidate and validate") {
             fun Validation.validate(i: Int) {


### PR DESCRIPTION
## Summary
- Add Japanese message translations in `kova_ja.properties` with complete coverage of all validation messages
- Fix all tests to use `Locale.US` by default to prevent locale-dependent test failures
- Add `MessagePropertiesJaTest` to verify Japanese message translations work correctly
- Update example tests to check constraint IDs instead of locale-dependent message text

## Test plan
- [x] All existing tests pass with default US locale
- [x] New test `MessagePropertiesJaTest` verifies Japanese translations
- [x] Tests are now locale-independent and won't fail in Japanese environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)