### PR TITLE
Refactor nullable validation with raiseIfNull helper function

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
@@ -78,11 +78,11 @@ fun <T> Validation.notNull(
 /**
  * Converts a nullable input to a non-nullable output with a custom constraint ID.
  *
- * This is an internal overload that allows specifying a custom constraint ID for the
+ * This is an internal function that allows specifying a custom constraint ID for the
  * null check validation. It validates that the input is not null and converts the output
  * type from `T?` to `T & Any`.
  *
- * This overload is primarily used internally by type conversion validators (e.g., [toInt],
+ * This function is primarily used internally by type conversion validators (e.g., [toInt],
  * [toLong], [toEnum]) that need to report errors with their specific constraint IDs
  * (e.g., "kova.string.isInt", "kova.string.isEnum") rather than the generic
  * "kova.nullable.notNull".


### PR DESCRIPTION
## Summary
- Extract common null-checking logic into a private `raiseIfNull` helper function
- Simplify `notNull` and `toNonNullable` implementations using the new helper
- Update KDoc for `toNonNullable` to reflect it's a function, not an overload

## Changes
- Add private `raiseIfNull` function that encapsulates the null validation pattern
- Refactor `notNull` to use `raiseIfNull` for cleaner implementation
- Refactor `toNonNullable` to use `raiseIfNull` and simplify return logic
- Fix KDoc terminology: "overload" → "function" in `toNonNullable` documentation

## Benefits
- Reduces code duplication in nullable validation logic
- Makes the codebase more maintainable
- Improves clarity of `toNonNullable` documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)