### PR TITLE
Include validator input in collection validation error messages

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/IterableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/IterableValidator.kt
@@ -100,11 +100,13 @@ fun <E> Validation.onEach(
     input: Iterable<E>,
     validate: Validation.(E) -> Unit,
 ) = input.constrain("kova.iterable.onEach") {
-    withMessage({ "kova.iterable.onEach".resource(it) }) {
-        for ((i, element) in input.withIndex()) {
-            accumulating {
-                appendPath("[$i]<iterable element>") {
-                    validate(element)
+    with(validation) {
+        withMessage({ "kova.iterable.onEach".resource(it) }) {
+            for ((i, element) in input.withIndex()) {
+                accumulating {
+                    appendPath("[$i]<iterable element>") {
+                        validate(element)
+                    }
                 }
             }
         }

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/MapValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/MapValidator.kt
@@ -219,12 +219,10 @@ fun <K, V> Validation.onEach(
     input: Map<K, V>,
     validator: Validation.(Map.Entry<K, V>) -> Unit,
 ) = input.constrain("kova.map.onEach") {
-    appendPath(text = "<map entry>") {
-        validateOnEach(
-            input,
-            "kova.map.onEach",
-            validator,
-        )
+    with(validation) {
+        validateOnEach(input, "kova.map.onEach") { entry ->
+            appendPath(text = "<map entry>") { validator(entry) }
+        }
     }
 }
 
@@ -253,8 +251,10 @@ fun <K> Validation.onEachKey(
     input: Map<K, *>,
     validator: Validation.(K) -> Unit,
 ) = input.constrain("kova.map.onEachKey") {
-    validateOnEach(input, "kova.map.onEachKey") { entry ->
-        appendPath(text = "<map key>") { validator(entry.key) }
+    with(validation) {
+        validateOnEach(input, "kova.map.onEachKey") { entry ->
+            appendPath(text = "<map key>") { validator(entry.key) }
+        }
     }
 }
 
@@ -283,8 +283,10 @@ fun <V> Validation.onEachValue(
     input: Map<*, V>,
     validator: Validation.(V) -> Unit,
 ) = input.constrain("kova.map.onEachValue") {
-    validateOnEach(input, "kova.map.onEachValue") { entry ->
-        appendPath(text = "[${entry.key}]<map value>") { validator(entry.value) }
+    with(validation) {
+        validateOnEach(input, "kova.map.onEachValue") { entry ->
+            appendPath(text = "[${entry.key}]<map value>") { validator(entry.value) }
+        }
     }
 }
 

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/IterableValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/IterableValidatorTest.kt
@@ -32,12 +32,14 @@ class IterableValidatorTest :
             }
 
             test("failure") {
-                val result = tryValidate { onEach(listOf("123", "4567", "8910")) { length(it, 3) } }
+                val input = listOf("123", "4567", "8910")
+                val result = tryValidate { onEach(input) { length(it, 3) } }
                 result.shouldBeFailure()
                 result.messages.single().let {
                     it.constraintId shouldBe "kova.iterable.onEach"
                     it.text shouldBe
                         "Some elements do not satisfy the constraint: [must be exactly 3 characters, must be exactly 3 characters]"
+                    it.input shouldBe input
                     it.args.single().shouldBeInstanceOf<List<Message>> { messages ->
                         messages.size shouldBe 2
                         messages[0].constraintId shouldBe "kova.charSequence.length"
@@ -63,6 +65,7 @@ class IterableValidatorTest :
                     it.constraintId shouldBe "kova.iterable.onEach"
                     it.text shouldBe
                         "Some elements do not satisfy the constraint: [must be exactly 3 characters]"
+                    it.input shouldBe listOf("123", "4567", "8910")
                     it.args
                         .single()
                         .shouldBeInstanceOf<List<Message>>()

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/MapValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/MapValidatorTest.kt
@@ -86,9 +86,11 @@ class MapValidatorTest :
             }
 
             test("failure") {
-                val result = tryValidate { validate(mapOf("a" to "a", "b" to "b")) }
+                val input = mapOf("a" to "a", "b" to "b")
+                val result = tryValidate { validate(input) }
                 result.shouldBeFailure()
                 result.messages[0].constraintId shouldBe "kova.map.onEach"
+                result.messages[0].input shouldBe input
             }
         }
 
@@ -99,10 +101,12 @@ class MapValidatorTest :
             }
 
             test("failure") {
-                val result = tryValidate { onEachKey(mapOf("a" to "1", "bb" to "2", "ccc" to "3")) { length(it, 1) } }
+                val input = mapOf("a" to "1", "bb" to "2", "ccc" to "3")
+                val result = tryValidate { onEachKey(input) { length(it, 1) } }
                 result.shouldBeFailure()
                 result.messages.size shouldBe 1
                 result.messages[0].constraintId shouldBe "kova.map.onEachKey"
+                result.messages[0].input shouldBe input
             }
         }
 
@@ -113,10 +117,12 @@ class MapValidatorTest :
             }
 
             test("failure") {
-                val result = tryValidate { onEachValue(mapOf("a" to "1", "b" to "22", "c" to "333")) { length(it, 1) } }
+                val input = mapOf("a" to "1", "b" to "22", "c" to "333")
+                val result = tryValidate { onEachValue(input) { length(it, 1) } }
                 result.shouldBeFailure()
                 result.messages.size shouldBe 1
                 result.messages[0].constraintId shouldBe "kova.map.onEachValue"
+                result.messages[0].input shouldBe input
             }
         }
 


### PR DESCRIPTION
## Summary
- Updated `onEach` validators for `Iterable` and `Map` to properly include the input value in error messages
- Fixed validators to use `with(validation)` scope to access the validation context
- Added test assertions to verify input field is populated in error messages

## Changes
- `IterableValidator.onEach`: Wrap validation in validation context
- `MapValidator.onEach`, `onEachKey`, `onEachValue`: Use validation context to include input
- Updated tests to verify `input` field in error messages

## Test plan
- [x] Existing tests pass
- [x] New test assertions verify input field is correctly populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)