### PR TITLE
Update KDoc examples to use modern validator API

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/Validation.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/Validation.kt
@@ -188,8 +188,8 @@ data class Validation(
      * data class User(val name: String, val age: Int)
      *
      * fun Validation.validate(user: User) = user.schema {
-     *     user::name { ensureNotBlank(it); ensureMinLength(it, 1); ensureMaxLength(it, 100) }
-     *     user::age { min(it, 0); max(it, 120) }
+     *     user::name { ensureNotBlank(it); ensureLengthInRange(it, 1..100) }
+     *     user::age { ensureMin(it, 0); ensureMax(it, 120) }
      * }
      *
      * tryValidate { validate(User("Alice", 30)) }
@@ -222,7 +222,7 @@ data class Validation(
      *
      * fun Validation.validate(user: User) = user.schema {
      *     user::name { ensureNotBlank(it); ensureMinLength(it, 1) }
-     *     user::age { min(it, 0); max(it, 120) }
+     *     user::age { ensureMin(it, 0); ensureMax(it, 120) }
      *     user::email { ensureNullOr(it) { ensureMatches(it, emailRegex) } }
      * }
      * ```

--- a/kova-factory/src/main/kotlin/org/komapper/extension/validator/factory/Factory.kt
+++ b/kova-factory/src/main/kotlin/org/komapper/extension/validator/factory/Factory.kt
@@ -45,8 +45,7 @@ inline fun <R> Validation.factory(
  * ```kotlin
  * val name by bind(rawName) {
  *     ensureNotBlank(it)
- *     min(it, 1)
- *     max(it, 50)
+ *     ensureLengthInRange(it, 1..50)
  *     it
  * }
  * val id by bind(rawId) { parseInt(it) }

--- a/kova-ktor/src/main/kotlin/org/komapper/extension/validator/ktor/server/SchemaValidator.kt
+++ b/kova-ktor/src/main/kotlin/org/komapper/extension/validator/ktor/server/SchemaValidator.kt
@@ -22,8 +22,7 @@ import org.komapper.extension.validator.tryValidate
  *         ::id { ensurePositive(it) }
  *         ::name {
  *             ensureNotBlank(it)
- *             min(it, 1)
- *             max(it, 100)
+ *             ensureLengthInRange(it, 1..100)
  *         }
  *     }
  * }

--- a/kova-ktor/src/main/kotlin/org/komapper/extension/validator/ktor/server/Validated.kt
+++ b/kova-ktor/src/main/kotlin/org/komapper/extension/validator/ktor/server/Validated.kt
@@ -17,8 +17,7 @@ import org.komapper.extension.validator.Validation
  *         ::id { ensurePositive(it) }
  *         ::name {
  *             ensureNotBlank(it)
- *             min(it, 1)
- *             max(it, 100)
+ *             ensureLengthInRange(it, 1..100)
  *         }
  *     }
  * }


### PR DESCRIPTION
## Summary
- Update KDoc code examples in source files to use modern Kova validator API
- Replace obsolete `min()`/`max()` with `ensureMin()`/`ensureMax()` for comparable validation
- Replace `ensureMinLength()`/`ensureMaxLength()` with `ensureLengthInRange()` for string length validation

## Changes
- **Validation.kt**: Update schema() KDoc examples
- **Factory.kt**: Update bind() KDoc example
- **SchemaValidator.kt**: Update class KDoc example
- **Validated.kt**: Update interface KDoc example

## Context
These changes align with previous refactoring in commits ba21e94 and b947b56 which introduced `ensureLengthInRange()` and updated README documentation, but missed these KDoc comments in source code.

## Test plan
- [x] Build successful (`./gradlew build`)
- [x] All tests pass
- [x] Visual inspection of updated KDoc examples
- [x] Verified consistency with README examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)