### PR TITLE
Fix incorrect constraint IDs in KDoc comments

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/CharSequenceValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/CharSequenceValidator.kt
@@ -1,7 +1,7 @@
 package org.komapper.extension.validator
 
 /**
- * Validates that the character sequence ensureLength is at least the specified minimum.
+ * Validates that the character sequence length is at least the specified minimum.
  *
  * Example:
  * ```kotlin
@@ -9,7 +9,7 @@ package org.komapper.extension.validator
  * tryValidate { ensureMinLength("hi", 3) }    // Failure
  * ```
  *
- * @param length Minimum ensureLength (inclusive)
+ * @param length Minimum length (inclusive)
  * @param message Custom error message provider
  */
 @IgnorableReturnValue
@@ -20,7 +20,7 @@ fun Validation.ensureMinLength(
 ) = input.constrain("kova.charSequence.minLength") { satisfies(it.length >= length, message) }
 
 /**
- * Validates that the character sequence ensureLength does not exceed the specified maximum.
+ * Validates that the character sequence length does not exceed the specified maximum.
  *
  * Example:
  * ```kotlin
@@ -28,7 +28,7 @@ fun Validation.ensureMinLength(
  * tryValidate { ensureMaxLength("very long string", 10) } // Failure
  * ```
  *
- * @param length Maximum ensureLength (inclusive)
+ * @param length Maximum length (inclusive)
  * @param message Custom error message provider
  */
 @IgnorableReturnValue
@@ -39,7 +39,7 @@ fun Validation.ensureMaxLength(
 ) = input.constrain("kova.charSequence.maxLength") { satisfies(it.length <= length, message) }
 
 /**
- * Validates that the character sequence is not ensureBlank (not ensureEmpty and not only whitespace).
+ * Validates that the character sequence is not blank (not empty and not only whitespace).
  *
  * Example:
  * ```kotlin
@@ -57,7 +57,7 @@ fun Validation.ensureNotBlank(
 ) = input.constrain("kova.charSequence.notBlank") { satisfies(it.isNotBlank(), message) }
 
 /**
- * Validates that the character sequence is ensureBlank (ensureEmpty or only whitespace).
+ * Validates that the character sequence is blank (empty or only whitespace).
  *
  * Example:
  * ```kotlin
@@ -75,12 +75,12 @@ fun Validation.ensureBlank(
 ) = input.constrain("kova.charSequence.blank") { satisfies(it.isBlank(), message) }
 
 /**
- * Validates that the character sequence is not ensureEmpty.
+ * Validates that the character sequence is not empty.
  *
  * Example:
  * ```kotlin
  * tryValidate { ensureNotEmpty("hello") } // Success
- * tryValidate { ensureNotEmpty("   ") }   // Success (ensureContains whitespace)
+ * tryValidate { ensureNotEmpty("   ") }   // Success (contains whitespace)
  * tryValidate { ensureNotEmpty("") }      // Failure
  * ```
  *
@@ -93,12 +93,12 @@ fun Validation.ensureNotEmpty(
 ) = input.constrain("kova.charSequence.notEmpty") { satisfies(it.isNotEmpty(), message) }
 
 /**
- * Validates that the character sequence is ensureEmpty.
+ * Validates that the character sequence is empty.
  *
  * Example:
  * ```kotlin
  * tryValidate { ensureEmpty("") }      // Success
- * tryValidate { ensureEmpty("   ") }   // Failure (ensureContains whitespace)
+ * tryValidate { ensureEmpty("   ") }   // Failure (contains whitespace)
  * tryValidate { ensureEmpty("hello") } // Failure
  * ```
  *
@@ -111,7 +111,7 @@ fun Validation.ensureEmpty(
 ) = input.constrain("kova.charSequence.empty") { satisfies(it.isEmpty(), message) }
 
 /**
- * Validates that the character sequence ensureLength equals exactly the specified value.
+ * Validates that the character sequence length equals exactly the specified value.
  *
  * Example:
  * ```kotlin
@@ -119,7 +119,7 @@ fun Validation.ensureEmpty(
  * tryValidate { ensureLength("hi", 5) }    // Failure
  * ```
  *
- * @param ensureLength Exact ensureLength required
+ * @param length Exact length required
  * @param message Custom error message provider
  */
 @IgnorableReturnValue

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/NullableValidator.kt
@@ -5,7 +5,7 @@ import kotlin.contracts.contract
 /**
  * Validates that the input is null.
  *
- * This constraint fails if the input is non-null. Uses the "kova.nullable.ensureNull"
+ * This constraint fails if the input is non-null. Uses the "kova.nullable.null"
  * constraint ID.
  *
  * Example:
@@ -54,7 +54,7 @@ inline fun <T> Validation.ensureNullOr(
 /**
  * Validates that the input is not null.
  *
- * This constraint fails if the input is null. Uses the "kova.nullable.ensureNotNull"
+ * This constraint fails if the input is null. Uses the "kova.nullable.notNull"
  * constraint ID.
  *
  * Example:
@@ -85,7 +85,7 @@ fun <T> Validation.ensureNotNull(
  * This function is primarily used internally by type conversion validators (e.g., [parseInt],
  * [parseLong], [parseEnum]) that need to report errors with their specific constraint IDs
  * (e.g., "kova.string.ensureInt", "kova.string.ensureEnum") rather than the generic
- * "kova.nullable.ensureNotNull".
+ * "kova.nullable.notNull".
  *
  * The function uses [constrain] to properly track the validation path context and returns
  * the accumulated value, ensuring proper error reporting in nested validation scenarios.


### PR DESCRIPTION
## Summary
- Fixed incorrect constraint ID documentation in NullableValidator.kt (3 occurrences)
- Fixed incorrect terminology in CharSequenceValidator.kt (12 occurrences)
- All KDoc comments now correctly reference actual constraint IDs matching kova.properties

## Changes
### NullableValidator.kt
- `"kova.nullable.ensureNull"` → `"kova.nullable.null"`
- `"kova.nullable.ensureNotNull"` → `"kova.nullable.notNull"`

### CharSequenceValidator.kt
- Removed incorrect "ensure" prefix from terminology:
  - `"ensureLength"` → `"length"`
  - `"ensureBlank"` → `"blank"`
  - `"ensureEmpty"` → `"empty"`
  - `"ensureContains"` → `"contains"`

## Test plan
- [x] Build verification passed (`./gradlew build`)
- [x] All constraint IDs verified against kova.properties
- [x] Documentation style consistent with other validator files

🤖 Generated with [Claude Code](https://claude.com/claude-code)