### PR TITLE
[codex] Remove REPO_ACCESS_TOKEN from release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to check out
+        required: false
+        type: string
+      publish:
+        description: Publish packages after verification
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -16,6 +27,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        ref: ${{ inputs.ref || github.ref }}
 
     - name: Set up JDK 17
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -48,7 +61,7 @@ jobs:
           !**/build/libs/*-plain.jar
 
   publish:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.publish
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [ build ]
@@ -56,6 +69,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
- 
+    permissions:
+      contents: write
+    outputs:
+      release_ref: ${{ steps.release-ref.outputs.release_ref }}
+
     steps:
       - name: Assign input version
-        if: github.event.inputs.version != null
-        run: echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+        if: inputs.version != ''
+        run: echo "RELEASE_VERSION=${{ inputs.version }}" >> $GITHUB_ENV
 
       - name: Get latest draft release title
-        if: github.event.inputs.version == null
+        if: inputs.version == ''
         run: |
           TITLE=$(gh api repos/${{ github.repository }}/releases \
             --jq '.[] | select(.draft==true) | .name' | head -n 1)
@@ -41,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          fetch-depth: 0
 
       - name: Prepare git config
         run: |
@@ -54,9 +58,22 @@ jobs:
       - name: Release ${{ env.RELEASE_VERSION }}
         run: ./gradlew release -Prelease.releaseVersion=${{ env.RELEASE_VERSION }}
 
+      - name: Assign release ref
+        id: release-ref
+        run: echo "release_ref=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
       - name: Upload reports
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build
           path: ./**/build/reports
+
+  verify-and-publish:
+    name: Verify and Publish
+    needs: release
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ needs.release.outputs.release_ref }}
+      publish: true
+    secrets: inherit


### PR DESCRIPTION
## Summary
- remove `secrets.REPO_ACCESS_TOKEN` from the release workflow
- grant the release job `contents: write` and use the default token-backed checkout for release commits and tags
- call the CI workflow as a reusable workflow so workflow_dispatch releases still verify and publish the created tag

## Verification
- rg -n "REPO_ACCESS_TOKEN" .github/workflows
- git diff --check
- YAML parse check for .github/workflows/ci.yml and .github/workflows/release.yml