### PR TITLE
Update dependency org.jetbrains.kotlin to v2.4.0 and remove -Xcontext-parameters flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ For API documentation and usage examples, see [`Package.md`](kova-core/src/main/
 
 **Stack**: Kotlin, Gradle 8.14, Java 17, Kotest, Ktor 3.0.0+
 
-**Requires**: `-Xcontext-parameters` compiler flag (configured in build.gradle.kts)
+**Note**: Kova's API relies on context parameters, which are enabled by default since Kotlin 2.4.0 (no `-Xcontext-parameters` flag required).
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -92,19 +92,11 @@ dependencies {
 }
 ```
 
-Enable Kotlin's context parameters feature:
-
-```kotlin
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-parameters")
-    }
-}
-```
+Kova's API is built around Kotlin's context parameters, which are enabled by default since Kotlin 2.4.0. No additional compiler flag is required.
 
 ### Requirements
 
-- Kotlin 2.3.0+
+- Kotlin 2.4.0+
 - Java 17+
 - Gradle 8.14+
 
@@ -560,9 +552,9 @@ tryValidate { /* ... */ }
 tryValidate(ValidationConfig(failFast = true)) { /* ... */ }
 ```
 
-### Can I use Kova without the context parameters compiler flag?
+### Do I need the context parameters compiler flag?
 
-No. The `-Xcontext-parameters` flag is required because Kova's API is built around context parameters. This is a deliberate design choice that enables the clean, fluent API.
+No. Since Kotlin 2.4.0, context parameters are enabled by default, so the `-Xcontext-parameters` flag is no longer required. Kova's API is built around context parameters — a deliberate design choice that enables the clean, fluent API.
 
 ## License
 

--- a/example-core/build.gradle.kts
+++ b/example-core/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.addAll("-Xreturn-value-checker=full", "-Xcontext-parameters")
+        freeCompilerArgs.addAll("-Xreturn-value-checker=full")
     }
     jvmToolchain(17)
 }

--- a/example-exposed/build.gradle.kts
+++ b/example-exposed/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.addAll("-Xreturn-value-checker=full", "-Xcontext-parameters")
+        freeCompilerArgs.addAll("-Xreturn-value-checker=full")
     }
     jvmToolchain(17)
 }

--- a/example-hibernate-validator/build.gradle.kts
+++ b/example-hibernate-validator/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.addAll("-Xreturn-value-checker=full", "-Xcontext-parameters")
+        freeCompilerArgs.addAll("-Xreturn-value-checker=full")
     }
     jvmToolchain(17)
 }

--- a/example-konform/build.gradle.kts
+++ b/example-konform/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.addAll("-Xreturn-value-checker=full", "-Xcontext-parameters")
+        freeCompilerArgs.addAll("-Xreturn-value-checker=full")
     }
     jvmToolchain(17)
 }

--- a/example-ktor/build.gradle.kts
+++ b/example-ktor/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.addAll("-Xreturn-value-checker=full", "-Xcontext-parameters")
+        freeCompilerArgs.addAll("-Xreturn-value-checker=full")
     }
     jvmToolchain(17)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 ktor = "3.5.0"
 logback = "1.5.33"
 kotest = "6.1.11"

--- a/kova-core/build.gradle.kts
+++ b/kova-core/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.addAll(
             "-Xreturn-value-checker=full",
-            "-Xcontext-parameters",
             "-opt-in=kotlin.contracts.ExperimentalContracts",
         )
     }

--- a/kova-ktor/build.gradle.kts
+++ b/kova-ktor/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 kotlin {
     explicitApi()
     compilerOptions {
-        freeCompilerArgs.addAll("-Xreturn-value-checker=full", "-Xcontext-parameters")
+        freeCompilerArgs.addAll("-Xreturn-value-checker=full")
     }
     jvmToolchain(17)
 }


### PR DESCRIPTION
## Summary

Updates Kotlin from `2.3.21` to `2.4.0`. Since context parameters are enabled by default starting with Kotlin 2.4.0, the `-Xcontext-parameters` compiler flag is no longer required, so it has been removed from all modules.

## Changes

- Bump `kotlin`: `2.3.21` → `2.4.0` in `gradle/libs.versions.toml`
- Remove `-Xcontext-parameters` from all module build scripts (`kova-core`, `kova-ktor`, `example-core`, `example-ktor`, `example-exposed`, `example-hibernate-validator`, `example-konform`)
- Update `README.md` and `CLAUDE.md` to reflect that the flag is no longer needed (Kotlin requirement bumped to 2.4.0+)

## Verification

- `./gradlew build --rerun-tasks` — all 38 tasks pass with the flag removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)