### PR TITLE
Use pull_request_target for autolabeler to support fork PRs

### DIFF
--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,7 +1,10 @@
 name: Autolabeler
 
+# Use pull_request_target (not pull_request) so the GITHUB_TOKEN keeps
+# write permissions for PRs from forks. Safe because this workflow never
+# checks out or runs PR code.
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
## What changed

Switched the autolabeler workflow trigger from `pull_request` to `pull_request_target`.

## Why

The autolabeler job failed on PR #229 with `Resource not accessible by integration` (see [this run](https://github.com/komapper/kova/actions/runs/27386712869)). The PR comes from a fork, and with the `pull_request` event GitHub always downgrades the `GITHUB_TOKEN` to read-only for fork PRs — the `pull-requests: write` permission declared in the workflow is silently capped, so the action cannot add labels.

`pull_request_target` runs the workflow in the context of the base repository, so the token retains write access even for fork PRs. This is the approach release-drafter documents for its autolabeler.

## Notes for reviewers

- This is safe because the workflow has no `checkout` step and never executes code from the PR; it only reads PR metadata (title, branch, changed file paths) to assign labels.
- `pull_request_target` workflows run from the base branch version of the file, so the fix takes effect once this lands on `main`. For PR #229, the labeler will run again on the next push to that PR (or close/reopen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)