### PR TITLE
Fix validation path prefix loss and duplicate log entries

### DIFF
--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/Path.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/Path.kt
@@ -32,8 +32,8 @@ public inline fun <R> addRoot(
 ): R =
     block(
         if (v.root.isEmpty()) {
-            // initialize root
-            v.copy(root = name, path = Path(name = "", obj = obj, parent = null))
+            // initialize root, keeping path segments added before the root (e.g. by capture or named)
+            v.copy(root = name, path = Path(name = "", obj = obj, parent = v.path))
         } else {
             v
         },
@@ -205,8 +205,12 @@ public data class Path(
      */
     val fullName: String
         get() {
-            if (parent == null || parent.name.isEmpty()) return name
-            return if (name.isEmpty()) parent.fullName else "${parent.fullName}.$name"
+            val prefix = parent?.fullName ?: ""
+            return when {
+                name.isEmpty() -> prefix
+                prefix.isEmpty() -> name
+                else -> "$prefix.$name"
+            }
         }
 
     /**

--- a/kova-core/src/main/kotlin/org/komapper/extension/validator/StringValidator.kt
+++ b/kova-core/src/main/kotlin/org/komapper/extension/validator/StringValidator.kt
@@ -204,7 +204,10 @@ context(_: Validation)
 public fun <E : Enum<E>> String.ensureEnum(
     klass: KClass<E>,
     message: (validNames: List<String>) -> Message = { "kova.string.enum".resource(it) },
-): String = constrain("kova.string.enum") { val _ = it.transformToEnum(klass, message) }
+): String =
+    constrain("kova.string.enum") {
+        satisfies(it.toEnumOrNull(klass) != null) { message(klass.java.enumConstants.map { enum -> enum.name }) }
+    }
 
 /**
  * Validates that the string is a valid name for the specified enum type (reified version).
@@ -249,7 +252,7 @@ context(_: Validation)
 public fun String.ensureDate(
     formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE,
     message: MessageProvider = { "kova.string.localDate".resource },
-): String = constrain("kova.string.localDate") { val _ = it.transformToDate(formatter, message) }
+): String = constrain("kova.string.localDate") { satisfies(it.toLocalDateOrNull(formatter) != null, message) }
 
 /**
  * Validates that the string can be parsed as a LocalDateTime.
@@ -272,7 +275,7 @@ context(_: Validation)
 public fun String.ensureDateTime(
     formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME,
     message: MessageProvider = { "kova.string.localDateTime".resource },
-): String = constrain("kova.string.localDateTime") { val _ = it.transformToDateTime(formatter, message) }
+): String = constrain("kova.string.localDateTime") { satisfies(it.toLocalDateTimeOrNull(formatter) != null, message) }
 
 /**
  * Validates that the string can be parsed as a LocalTime.
@@ -295,7 +298,7 @@ context(_: Validation)
 public fun String.ensureTime(
     formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_TIME,
     message: MessageProvider = { "kova.string.localTime".resource },
-): String = constrain("kova.string.localTime") { val _ = it.transformToTime(formatter, message) }
+): String = constrain("kova.string.localTime") { satisfies(it.toLocalTimeOrNull(formatter) != null, message) }
 
 /**
  * Validates that the string is in ensureUppercase.
@@ -591,10 +594,7 @@ context(_: Validation)
 public fun String.transformToDate(
     formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE,
     message: MessageProvider = { "kova.string.localDate".resource },
-): LocalDate =
-    transformOrRaise("kova.string.localDate", message) {
-        runCatching { LocalDate.parse(it, formatter) }.getOrNull()
-    }
+): LocalDate = transformOrRaise("kova.string.localDate", message) { it.toLocalDateOrNull(formatter) }
 
 /**
  * Validates that the string can be parsed as a LocalDateTime and converts it.
@@ -618,10 +618,7 @@ context(_: Validation)
 public fun String.transformToDateTime(
     formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME,
     message: MessageProvider = { "kova.string.localDateTime".resource },
-): LocalDateTime =
-    transformOrRaise("kova.string.localDateTime", message) {
-        runCatching { LocalDateTime.parse(it, formatter) }.getOrNull()
-    }
+): LocalDateTime = transformOrRaise("kova.string.localDateTime", message) { it.toLocalDateTimeOrNull(formatter) }
 
 /**
  * Validates that the string can be parsed as a LocalTime and converts it.
@@ -645,7 +642,17 @@ context(_: Validation)
 public fun String.transformToTime(
     formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_TIME,
     message: MessageProvider = { "kova.string.localTime".resource },
-): LocalTime =
-    transformOrRaise("kova.string.localTime", message) {
-        runCatching { LocalTime.parse(it, formatter) }.getOrNull()
-    }
+): LocalTime = transformOrRaise("kova.string.localTime", message) { it.toLocalTimeOrNull(formatter) }
+
+private fun String.toLocalDateOrNull(formatter: DateTimeFormatter): LocalDate? =
+    runCatching {
+        LocalDate.parse(this, formatter)
+    }.getOrNull()
+
+private fun String.toLocalDateTimeOrNull(formatter: DateTimeFormatter): LocalDateTime? =
+    runCatching { LocalDateTime.parse(this, formatter) }.getOrNull()
+
+private fun String.toLocalTimeOrNull(formatter: DateTimeFormatter): LocalTime? =
+    runCatching {
+        LocalTime.parse(this, formatter)
+    }.getOrNull()

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/CaptureTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/CaptureTest.kt
@@ -128,6 +128,38 @@ class CaptureTest :
             }
         }
 
+        context("factory with schema validation inside capture") {
+            data class User(
+                val name: String,
+            )
+
+            context(_: Validation)
+            fun buildUser(name: String): User {
+                val user by capture {
+                    val u = User(name)
+                    u.schema {
+                        u::name { it.ensureNotBlank() }
+                    }
+                    u
+                }
+                return user
+            }
+
+            test("success") {
+                val result = tryValidate { buildUser("abc") }
+                result.shouldBeSuccess()
+                result.value shouldBe User("abc")
+            }
+
+            test("failure keeps the capture path prefix") {
+                val result = tryValidate { buildUser("") }
+                result.shouldBeFailure()
+                result.messages.size shouldBe 1
+                result.messages[0].constraintId shouldBe "kova.charSequence.notBlank"
+                result.messages[0].path.fullName shouldBe "user.name"
+            }
+        }
+
         context("standalone constrain for argument correlation") {
             data class DateRange(
                 val start: Int,

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/SchemaTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/SchemaTest.kt
@@ -512,4 +512,27 @@ class SchemaTest :
                 result.messages[0].constraintId.shouldNotBeNull() shouldBeEqual "kova.comparable.atMost"
             }
         }
+
+        context("schema inside named block") {
+            context(_: Validation)
+            fun validate(user: User) =
+                user.named("payload") {
+                    it.schema {
+                        it::name { name -> name.ensureNotBlank() }
+                    }
+                }
+
+            test("success") {
+                val result = tryValidate { validate(User(1, "abc")) }
+                result.shouldBeSuccess()
+            }
+
+            test("failure keeps the named path prefix") {
+                val result = tryValidate { validate(User(1, "")) }
+                result.shouldBeFailure()
+                result.messages.size shouldBe 1
+                result.messages[0].constraintId shouldBe "kova.charSequence.notBlank"
+                result.messages[0].path.fullName shouldBe "payload.name"
+            }
+        }
     })

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/StringValidatorTest.kt
@@ -657,6 +657,34 @@ class StringValidatorTest :
                 result.messages.single().input shouldBe "invalid"
             }
         }
+
+        context("logging of wrapper validators") {
+            fun violatedLogs(block: context(Validation)() -> Unit): List<LogEntry> {
+                val logs = mutableListOf<LogEntry>()
+                tryValidate(ValidationConfig(logger = { logs.add(it) })) { block() }.shouldBeFailure()
+                return logs.filterIsInstance<LogEntry.Violated>()
+            }
+
+            fun satisfiedLogs(block: context(Validation)() -> Unit): List<LogEntry> {
+                val logs = mutableListOf<LogEntry>()
+                tryValidate(ValidationConfig(logger = { logs.add(it) })) { block() }.shouldBeSuccess()
+                return logs.filterIsInstance<LogEntry.Satisfied>()
+            }
+
+            test("a single violation produces a single Violated entry") {
+                violatedLogs { "invalid".ensureDate() }.size shouldBe 1
+                violatedLogs { "invalid".ensureDateTime() }.size shouldBe 1
+                violatedLogs { "invalid".ensureTime() }.size shouldBe 1
+                violatedLogs { "INVALID".ensureEnum<Status>() }.size shouldBe 1
+            }
+
+            test("a single success produces a single Satisfied entry") {
+                satisfiedLogs { "2025-01-17".ensureDate() }.size shouldBe 1
+                satisfiedLogs { "2025-01-17T10:30:00".ensureDateTime() }.size shouldBe 1
+                satisfiedLogs { "10:30:00".ensureTime() }.size shouldBe 1
+                satisfiedLogs { "ACTIVE".ensureEnum<Status>() }.size shouldBe 1
+            }
+        }
     }) {
     enum class Status {
         ACTIVE,

--- a/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidationTest.kt
+++ b/kova-core/src/test/kotlin/org/komapper/extension/validator/ValidationTest.kt
@@ -20,7 +20,7 @@ class ValidationContextTest :
             test("no root") {
                 context(Validation(path = Path("c", null, null))) {
                     addRoot("a", null) {
-                        contextOf<Validation>() shouldBe Validation("a", Path("", null, null))
+                        contextOf<Validation>() shouldBe Validation("a", Path("", null, Path("c", null, null)))
                     }
                 }
             }
@@ -36,7 +36,7 @@ class ValidationContextTest :
             test("add empty") {
                 context(Validation(path = Path("c", null, null))) {
                     addRoot("", null) {
-                        contextOf<Validation>() shouldBe Validation("", Path("", null, null))
+                        contextOf<Validation>() shouldBe Validation("", Path("", null, Path("c", null, null)))
                     }
                 }
             }
@@ -177,9 +177,9 @@ class ValidationContextTest :
                 val grandparent = Path("company", null, null)
                 val parent = Path("", null, grandparent)
                 val path = Path("name", null, parent)
-                // When parent name is empty, it's treated as "no parent"
-                // so grandparent is ignored
-                path.fullName shouldBe "name"
+                // An empty-named node (e.g. a root initialized by addRoot) is skipped,
+                // keeping ancestor segments
+                path.fullName shouldBe "company.name"
             }
         }
 


### PR DESCRIPTION
## Summary

This PR fixes two bugs found during a review of the validation core, each in its own commit.

### 1. Path prefix loss when `schema` is used inside `capture` or `named` (4fdffd6)

`addRoot` replaced the entire path with a fresh root node when initializing the validation root, discarding path segments added beforehand by `capture` or `named`. As a result, error paths like `user.name` were reported as just `name`:

```kotlin
val user by capture {
    val u = User(name)
    u.schema { u::name { it.ensureNotBlank() } }
    u
}
// error path was "name", now "user.name"
```

Fix:
- `addRoot` keeps the existing path as the parent of the new root node.
- `Path.fullName` skips empty-named nodes anywhere in the chain instead of truncating ancestor segments when the immediate parent's name is empty.

Three existing tests in `ValidationTest.kt` asserted the old behavior exactly (fresh root with `parent = null`, and ancestor truncation on an empty name in the middle); they have been updated to the corrected semantics.

### 2. Duplicate log entries in `ensureDate`/`ensureDateTime`/`ensureTime`/`ensureEnum` (39896c1)

These validators wrapped their `transformTo*` counterparts inside `constrain` with the same constraint ID, so a single evaluation went through two nested constraint checks and emitted two identical `Satisfied`/`Violated` log entries.

Fix: check the condition directly with `satisfies`, using nullable parse helpers (`toLocalDateOrNull`, etc.) that are shared with the `transformTo*` functions. Validation results and messages are unchanged; only the logging behavior is affected.

## Notes for reviewers

- No public API signature changes; the binary compatibility dumps in `api/` are untouched and `apiCheck` passes.
- Regression tests added in `CaptureTest.kt`, `SchemaTest.kt`, and `StringValidatorTest.kt`.
- `./gradlew build` (all tests, apiCheck, spotless) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)