### PR TITLE
Update library version to 0.4.0 in README Setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Add Kova to your Gradle project:
 ```kotlin
 dependencies {
     // Core validation library
-    implementation("org.komapper:kova-core:0.3.1")
+    implementation("org.komapper:kova-core:0.4.0")
 
     // Ktor integration (optional)
-    implementation("org.komapper:kova-ktor:0.3.1")
+    implementation("org.komapper:kova-ktor:0.4.0")
 }
 ```
 


### PR DESCRIPTION
## Summary

The Setup section of the README referenced an outdated library version (`0.3.1`). This updates both `kova-core` and `kova-ktor` dependency examples to the latest version `0.4.0`.

## Changes

- `kova-core`: `0.3.1` → `0.4.0`
- `kova-ktor`: `0.3.1` → `0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)